### PR TITLE
Fix formatting issues

### DIFF
--- a/carina/src/Carina.vue
+++ b/carina/src/Carina.vue
@@ -233,7 +233,7 @@
       location="bottom"
       v-model="showTextSheet"
     >
-      <v-card>
+      <v-card height="100%">
       <!-- <v-container height="11px">
         <font-awesome-icon
           class="close-icon"
@@ -294,6 +294,7 @@
                 Peter Williams<br>
                 A. David Weigel<br>
                 Jon Carifio<br>
+                <br><br><br><br>
               </v-card-text>
             </v-card>
           </v-window-item>
@@ -358,6 +359,7 @@
                       Peter Williams<br>
                       A. David Weigel<br>
                       Jon Carifio<br>
+                      <br><br><br><br>
                     </v-col>
                   </v-row>
                 </v-container>              
@@ -630,16 +632,17 @@ export default defineComponent({
 
 <style lang="less">
 html {
-  height: 100%;
+  height: 100vh;
   margin: 0;
   padding: 0;
   background-color: #000;
+  overflow: hidden;
 }
 
 body {
+  position: fixed;
   width: 100%;
-  height: 100%;
-  overflow: hidden;
+  height: 100vh;
   margin: 0;
   padding: 0;
 
@@ -652,10 +655,10 @@ body {
   margin: 0;
 
   .wwtelescope-component {
-    position: relative;
+    position: absolute;
     top: 0;
     width: 100%;
-    height: 100vh;
+    height: 100%;
     border-style: none;
     border-width: 0;
     margin: 0;
@@ -958,6 +961,10 @@ video {
   display: none;
 }
 
+.v-window-item {
+  height: fit-content;
+}
+
 #tabs {
   width: calc(100% - 3em);
   align-self: left;
@@ -971,6 +978,7 @@ video {
     padding-top: ~"max(2vw, 16px)";
     padding-left: ~"max(4vw, 16px)";
     padding-right: ~"max(4vw, 16px)";
+    padding-bottom: ~"max(4vw, 25px)";
   }
 
 }

--- a/carina/src/Carina.vue
+++ b/carina/src/Carina.vue
@@ -225,11 +225,13 @@
       </div>
     </v-container>
 
-    <v-navigation-drawer
+    <v-dialog
+      class="bottom-sheet"
       id="text-bottom-sheet"  
       hide-overlay
       persistent
       absolute
+      width="100%"
       location="bottom"
       v-model="showTextSheet"
     >
@@ -294,7 +296,7 @@
                 Peter Williams<br>
                 A. David Weigel<br>
                 Jon Carifio<br>
-                <br><br><br><br>
+                <v-spacer class="end-spacer"></v-spacer>
               </v-card-text>
             </v-card>
           </v-window-item>
@@ -359,7 +361,7 @@
                       Peter Williams<br>
                       A. David Weigel<br>
                       Jon Carifio<br>
-                      <br><br><br><br>
+                      <v-spacer class="end-spacer"></v-spacer>
                     </v-col>
                   </v-row>
                 </v-container>              
@@ -368,7 +370,7 @@
           </v-window-item>
         </v-window>
       </v-card>
-    </v-navigation-drawer>
+    </v-dialog>
   </v-app>
 </template>
 
@@ -898,8 +900,13 @@ body {
   }
 }
 
-.v-bottom-sheet {
-  background: black;
+.bottom-sheet {
+  .v-overlay__content {
+    align-self: flex-end;
+    padding: 0;
+    margin: 0;
+    max-width: 100%;
+  }
 }
 
 .v-dialog--fullscreen {
@@ -909,6 +916,7 @@ body {
 
 .info-text {
   height: 35vh;
+  padding-bottom: 25px;
 
   & a {
     text-decoration: none;
@@ -973,12 +981,15 @@ video {
 #tab-items {
   // padding-bottom: 2px !important;
 
-  .v-card__text {
+  .v-card-text {
     font-size: ~"max(14px, calc(0.8em + 0.3vw))";
     padding-top: ~"max(2vw, 16px)";
     padding-left: ~"max(4vw, 16px)";
     padding-right: ~"max(4vw, 16px)";
-    padding-bottom: ~"max(4vw, 25px)";
+
+    .end-spacer {
+      height: 25px;
+    }
   }
 
 }
@@ -1058,6 +1069,10 @@ video {
 
   #tabs h3 {
     font-size: 1em;
+  }
+
+  #tab-items .v-card-text .end-spacer {
+    height: 70px;
   }
 }
 

--- a/carina/src/Carina.vue
+++ b/carina/src/Carina.vue
@@ -232,8 +232,10 @@
       persistent
       absolute
       width="100%"
+      :scrim="false"
       location="bottom"
       v-model="showTextSheet"
+      transition="dialog-bottom-transition"
     >
       <v-card height="100%">
       <!-- <v-container height="11px">


### PR DESCRIPTION
While looking at the Carina story on mobile, I noticed a few issues with the CSS, which this PR looks to remedy. Some tweaking of the overall containers and swapping the navigation drawer for a dialog are the main changes here.

Since the bottom text/tabs pattern is one I expect we'll use often, I'll probably refactor the bottom dialog into its own component (v-bottom-sheet seems to have been dropped in Vuetify 3). That's a task for another day, though.