### PR TITLE
Change alt/az grid color

### DIFF
--- a/c2022-e3/src/C2022E3.vue
+++ b/c2022-e3/src/C2022E3.vue
@@ -145,11 +145,22 @@
 
     <div class="bottom-content">
       <div
-        id="center-view-button"
-        class="ui-button clickable"
-        @click="updateViewForDate"
+        id="buttons-container"
       >
-        Center View on Date
+        <div
+          id="toggle-altaz-button"
+          class="ui-button clickable"
+          @click="showAltAzGrid = !showAltAzGrid"
+        >
+          {{ (showAltAzGrid ? 'Hide' : 'Show') + ' Grid' }} 
+        </div>
+        <div
+          id="center-view-button"
+          class="ui-button clickable"
+          @click="updateViewForDate"
+        >
+          Center View on Date
+        </div>
       </div>
       <div id="tools">
         <span class="tool-container">
@@ -524,6 +535,8 @@ export default defineComponent({
       imagesetFolder: null as Folder | null,
       backgroundImagesets: [] as BackgroundImageset[],
       decRadLowerBound: 0.2,
+
+      showAltAzGrid: true,
 
       dailyDates: dailyDates,
       weeklyDates: weeklyDates,
@@ -1142,6 +1155,9 @@ export default defineComponent({
     //     });
     //   }
     // },
+    showAltAzGrid(show: boolean) {
+      this.wwtSettings.set_showAltAzGrid(show);
+    },
     location(loc: LocationRad) {
       const now = this.selectedDate;
       const raDec = this.horizontalToEquatorial(Math.PI/2, 0, loc.latitudeRad, loc.longitudeRad, now);
@@ -1397,6 +1413,7 @@ body {
 }
 
 .ui-button {
+  text-align: center;
   color: var(--comet-color);
   background: black;
   padding: 5px 5px;
@@ -1414,8 +1431,14 @@ body {
   }
 }
 
-#center-view-button {
+#buttons-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
   align-self: flex-end;
+}
+
+#center-view-button {
   margin-bottom: 25px;
 }
 

--- a/c2022-e3/src/C2022E3.vue
+++ b/c2022-e3/src/C2022E3.vue
@@ -698,9 +698,8 @@ export default defineComponent({
         this.layersLoaded = true;
       });
 
-      //settings.set_localHorizonMode(true);
+      this.wwtSettings.set_localHorizonMode(true);
       this.wwtSettings.set_showAltAzGrid(true);
-
 
       // This is kinda horrible, but it works!
 

--- a/c2022-e3/src/C2022E3.vue
+++ b/c2022-e3/src/C2022E3.vue
@@ -752,9 +752,7 @@ export default defineComponent({
       }
     },
     wwtControl(): WWTControl {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      return WWTControl.singleton
+      return WWTControl.singleton;
     },
     wwtRenderContext() {
       return this.wwtControl.renderContext;

--- a/c2022-e3/src/C2022E3.vue
+++ b/c2022-e3/src/C2022E3.vue
@@ -398,7 +398,8 @@ import { defineComponent } from 'vue';
 import { csvFormatRows, csvParse } from "d3-dsv";
 
 import { distance, fmtDegLat, fmtDegLon, fmtHours } from "@wwtelescope/astro";
-import { Color, Folder, Poly, Settings, SpreadSheetLayer } from "@wwtelescope/engine";
+import { Color, Folder, Grids, Poly, RenderContext, Settings, WWTControl } from "@wwtelescope/engine";
+import { engineStore } from "@wwtelescope/engine-pinia";
 import { ImageSetType, PlotTypes } from "@wwtelescope/engine-types";
 
 import L, { LeafletMouseEvent, Map } from "leaflet";
@@ -564,7 +565,7 @@ export default defineComponent({
       // This is just nice for hacking while developing
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
-      window.wwt = this; window.settings = this.getSettings();
+      window.wwt = this; window.settings = this.wwtSettings;
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       window.applyISLSetting = applyImageSetLayerSetting;
@@ -697,8 +698,26 @@ export default defineComponent({
         this.layersLoaded = true;
       });
 
-      this.getSettings().set_localHorizonMode(true);
+      //settings.set_localHorizonMode(true);
+      this.wwtSettings.set_showAltAzGrid(true);
+
+
+      // This is kinda horrible, but it works!
+
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      this.wwtControl._drawSkyOverlays = function() {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        if (Settings.get_active().get_showAltAzGrid()) {
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          Grids.drawAltAzGrid(this.renderContext, 1, Color.fromArgb(1, 100, 136, 234));
+        }
+      }
+
       this.updateWWTLocation();
+      
 
     });
 
@@ -733,6 +752,19 @@ export default defineComponent({
         '--comet-color': this.cometColor
       }
     },
+    wwtControl(): WWTControl {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      return WWTControl.singleton
+    },
+    wwtRenderContext() {
+      return this.wwtControl.renderContext;
+    },
+    wwtSettings(): Settings {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      return Settings.get_active();
+    },
     showTextSheet: {
       get(): boolean {
         return this.sheet === 'text';
@@ -751,17 +783,10 @@ export default defineComponent({
     closeSplashScreen() {
       this.showSplashScreen = false;
     },
-    
-    getSettings(): Settings {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      return Settings.get_active();
-    },
-
+  
     updateWWTLocation() {
-      const settings = this.getSettings();
-      settings.set_locationLat(R2D * this.location.latitudeRad);
-      settings.set_locationLng(R2D * this.location.longitudeRad + 90);
+      this.wwtSettings.set_locationLat(R2D * this.location.latitudeRad);
+      this.wwtSettings.set_locationLng(R2D * this.location.longitudeRad + 90);
     },
 
     logLocation() {

--- a/c2022-e3/src/shims-wwt.d.ts
+++ b/c2022-e3/src/shims-wwt.d.ts
@@ -1,0 +1,7 @@
+import { Color, RenderContext } from "@wwtelescope/engine";
+
+declare module "@wwtelescope/engine" {
+  export class Grids {
+    static drawAltAzGrid(renderContext: RenderContext, opacity: number, drawColor: Color): void;
+  }
+}


### PR DESCRIPTION
This PR lets us change the alt/az grid color. This involved doing some TypeScript shenanigans that I normally wouldn't want to use, but hey, it works!

The basic idea is that we shim in the `Grids` class from `@wwtelescope/engine`, which exists in the engine code but isn't exported by the package. We only add the one method that we want, which draws the alt/az grid.

Next, we grab a reference to the `WWTControl` and manually change its `_drawSkyOverlays` method. This is the function that gets called during frame rendering to draw the various sky overlay grids. We only care about the alt/az grid, so this just drops the rest of the overlays from this function. In our updated method, we change the color that gets passed to the `Grids` method.

@patudom Feel free to change the color of the grid - it's set in line 714.