### PR TITLE
Change Leaflet maps to use HTTPS

### DIFF
--- a/green-comet/src/C2022E3.vue
+++ b/green-comet/src/C2022E3.vue
@@ -1053,7 +1053,7 @@ export default defineComponent({
       //   attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
       //   className: 'map-tiles'
       // }).addTo(map);
-      L.tileLayer('http://{s}.google.com/vt/lyrs=p&x={x}&y={y}&z={z}',{
+      L.tileLayer('https://{s}.google.com/vt/lyrs=p&x={x}&y={y}&z={z}',{
         maxZoom: 20,
         subdomains:['mt0','mt1','mt2','mt3'],
         attribution: `&copy <a href="https://www.google.com/maps">Google Maps</a>`,


### PR DESCRIPTION
This PR changes the URL of the Leaflet map layers to use HTTPS. This will hopefully fix the issue with the maps not loading in Safari.