### PR TITLE
Add NSEW labels to Alt/Az grid

### DIFF
--- a/green-comet/src/C2022E3.vue
+++ b/green-comet/src/C2022E3.vue
@@ -1529,7 +1529,7 @@ export default defineComponent({
     timeOfDay(_time: { hours: number; minutes: number; seconds: number }) {
       this.updateForDateTime();
     },
-    location(loc: LocationRad) {
+    location(loc: LocationRad, oldLoc: LocationRad) {
       //const now = this.selectedDate;
       //const raDec = this.horizontalToEquatorial(Math.PI/2, 0, loc.latitudeRad, loc.longitudeRad, now);
 
@@ -1538,6 +1538,10 @@ export default defineComponent({
 
         const locationDeg: [number, number] = [R2D * loc.latitudeRad, R2D * loc.longitudeRad];
         this.circle = this.circleForLocation(...locationDeg).addTo(this.map as Map); // Not sure, why, but TS is cranky w/o casting
+      }
+
+      if (oldLoc.latitudeRad * loc.latitudeRad < 0) {
+        Grids._altAzTextBatch = null;
       }
 
       this.updateHorizon();

--- a/green-comet/src/C2022E3.vue
+++ b/green-comet/src/C2022E3.vue
@@ -526,7 +526,7 @@ import { MiniDSBase, BackgroundImageset, skyBackgroundImagesets } from "@minids/
 import { ImageSetLayer, Place, Imageset } from "@wwtelescope/engine";
 import { applyImageSetLayerSetting } from "@wwtelescope/engine-helpers";
 
-import { drawSkyOverlays, initializeConstellationNames } from "./wwt-hacks";
+import { drawSkyOverlays, initializeConstellationNames, makeAltAzGridText } from "./wwt-hacks";
 
 
 import {
@@ -832,6 +832,7 @@ export default defineComponent({
 
       this.wwtSettings.set_localHorizonMode(true);
       this.wwtSettings.set_showAltAzGrid(this.showAltAzGrid);
+      this.wwtSettings.set_showAltAzGridText(this.showAltAzGrid);
       this.wwtSettings.set_showConstellationLabels(this.showConstellations);
       this.wwtSettings.set_showConstellationFigures(this.showConstellations);
 
@@ -843,6 +844,7 @@ export default defineComponent({
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       Constellations.initializeConstellationNames = initializeConstellationNames;
+      Grids._makeAltAzGridText = makeAltAzGridText;
 
       this.updateWWTLocation();
 
@@ -1515,6 +1517,7 @@ export default defineComponent({
     // },
     showAltAzGrid(show: boolean) {
       this.wwtSettings.set_showAltAzGrid(show);
+      this.wwtSettings.set_showAltAzGridText(show);
     },
     showConstellations(show: boolean) {
       this.wwtSettings.set_showConstellationLabels(show);

--- a/green-comet/src/shims-wwt.d.ts
+++ b/green-comet/src/shims-wwt.d.ts
@@ -4,6 +4,7 @@ declare module "@wwtelescope/engine" {
   export class Grids {
     static drawAltAzGrid(renderContext: RenderContext, opacity: number, drawColor: Color): void;
     static _makeAltAzGridText(): void;
+    static _altAzTextBatch: Text3dBatch | null;
   }
 
   export class Text3dBatch {

--- a/green-comet/src/shims-wwt.d.ts
+++ b/green-comet/src/shims-wwt.d.ts
@@ -3,6 +3,7 @@ import { Color, RenderContext } from "@wwtelescope/engine";
 declare module "@wwtelescope/engine" {
   export class Grids {
     static drawAltAzGrid(renderContext: RenderContext, opacity: number, drawColor: Color): void;
+    static _makeAltAzGridText(): void;
   }
 
   export class Text3dBatch {

--- a/green-comet/src/wwt-hacks.ts
+++ b/green-comet/src/wwt-hacks.ts
@@ -46,12 +46,13 @@ export function makeAltAzGridText() {
   if (Grids._altAzTextBatch == null) {
     const glyphHeight = 70;
     Grids._altAzTextBatch = new Text3dBatch(glyphHeight);
+    const alt = 0.03;
     const directions = [
-      [[0,0,-1], "N"],
-      [[-1,0,0], "E"],
-      [[0,0,1], "S"],
-      [[1,0,-0.0095], "V"],
-      [[1,0,0.0095], "V"]
+      [[0, alt, -1], "N"],
+      [[-1, alt, 0], "E"],
+      [[0, alt, 1], "S"],
+      [[1, alt, -0.0095], "V"],
+      [[1, alt, 0.0095], "V"]
     ]
     directions.forEach(([v, text]) => {
       Grids._altAzTextBatch.add(new Text3d(Vector3d.create(...v), Vector3d.create(0, 1, 0), text, 75, 0.00018));

--- a/green-comet/src/wwt-hacks.ts
+++ b/green-comet/src/wwt-hacks.ts
@@ -3,7 +3,7 @@
 
  /* eslint-disable */
 
-import { Color, Colors, Constellations, Coordinates, Grids, GlyphItem, GlyphCache, Rectangle, Settings, Text3d, Text3dBatch, URLHelpers, Vector2d, Vector3d, WWTControl } from "@wwtelescope/engine";
+import { Color, Colors, Constellations, Coordinates, Grids, GlyphItem, GlyphCache, Rectangle, Settings, SpaceTimeController, Text3d, Text3dBatch, URLHelpers, Vector2d, Vector3d, WWTControl } from "@wwtelescope/engine";
 
 export function drawSkyOverlays() {
   if (Settings.get_active().get_showConstellationLabels()) {
@@ -46,7 +46,9 @@ export function makeAltAzGridText() {
   if (Grids._altAzTextBatch == null) {
     const glyphHeight = 70;
     Grids._altAzTextBatch = new Text3dBatch(glyphHeight);
-    const alt = 0.03;
+    const sign = SpaceTimeController.get_location().get_lat() < 0 ? -1 : 1;
+    const alt = 0.03 * sign;
+    const up = Vector3d.create(0, 1, 0);
     const directions = [
       [[0, alt, -1], "N"],
       [[-1, alt, 0], "E"],
@@ -55,7 +57,7 @@ export function makeAltAzGridText() {
       [[1, alt, 0.0095], "V"]
     ]
     directions.forEach(([v, text]) => {
-      Grids._altAzTextBatch.add(new Text3d(Vector3d.create(...v), Vector3d.create(0, 1, 0), text, 75, 0.00018));
+      Grids._altAzTextBatch.add(new Text3d(Vector3d.create(...v), up, text, 75, 0.00018));
     });
   }
 }

--- a/green-comet/src/wwt-hacks.ts
+++ b/green-comet/src/wwt-hacks.ts
@@ -3,7 +3,7 @@
 
  /* eslint-disable */
 
-import { Color, Colors, Constellations, Coordinates, Grids, Settings, Text3d, Text3dBatch, URLHelpers, Vector3d, WWTControl } from "@wwtelescope/engine";
+import { Color, Colors, Constellations, Coordinates, Grids, GlyphItem, GlyphCache, Rectangle, Settings, Text3d, Text3dBatch, URLHelpers, Vector2d, Vector3d, WWTControl } from "@wwtelescope/engine";
 
 export function drawSkyOverlays() {
   if (Settings.get_active().get_showConstellationLabels()) {
@@ -16,7 +16,11 @@ export function drawSkyOverlays() {
     WWTControl.constellationsFigures.draw(this.renderContext, false, 'UMA', false);
   }
   if (Settings.get_active().get_showAltAzGrid()) {
-    Grids.drawAltAzGrid(this.renderContext, 1, Color.fromArgb(1, 3, 92, 134));
+    const altAzColor = Color.fromArgb(1, 3, 92, 134);
+    Grids.drawAltAzGrid(this.renderContext, 1, altAzColor);
+    if (Settings.get_active().get_showAltAzGridText()) {
+      Grids.drawAltAzGridText(this.renderContext, 1, altAzColor);
+    }
   }
 }
 
@@ -37,3 +41,20 @@ export function initializeConstellationNames() {
     Constellations._namesBatch.add(new Text3d(center, up, name, textSize, 0.000125));
   });
 };
+
+export function makeAltAzGridText() {
+  if (Grids._altAzTextBatch == null) {
+    const glyphHeight = 70;
+    Grids._altAzTextBatch = new Text3dBatch(glyphHeight);
+    const directions = [
+      [[0,0,-1], "N"],
+      [[-1,0,0], "E"],
+      [[0,0,1], "S"],
+      [[1,0,-0.0095], "V"],
+      [[1,0,0.0095], "V"]
+    ]
+    directions.forEach(([v, text]) => {
+      Grids._altAzTextBatch.add(new Text3d(Vector3d.create(...v), Vector3d.create(0, 1, 0), text, 75, 0.00018));
+    });
+  }
+}

--- a/green-comet/src/wwt-hacks.ts
+++ b/green-comet/src/wwt-hacks.ts
@@ -48,7 +48,7 @@ export function makeAltAzGridText() {
     Grids._altAzTextBatch = new Text3dBatch(glyphHeight);
     const sign = SpaceTimeController.get_location().get_lat() < 0 ? -1 : 1;
     const alt = 0.03 * sign;
-    const up = Vector3d.create(0, 1, 0);
+    const up = Vector3d.create(0, sign, 0);
     const directions = [
       [[0, alt, -1], "N"],
       [[-1, alt, 0], "E"],


### PR DESCRIPTION
This PR adds labels to the Alt/Az grid at the four cardinal directions. The "W" is a bit funky - the set of glyphs used by the web engine actually [doesn't have a W](https://web.wwtassets.org/engine/assets/glyphs1.png), so I've faked it using two Vs.