### PR TITLE
Use point markers for daily layer

### DIFF
--- a/green-comet/src/C2022E3.vue
+++ b/green-comet/src/C2022E3.vue
@@ -526,7 +526,7 @@ import { MiniDSBase, BackgroundImageset, skyBackgroundImagesets } from "@minids/
 import { ImageSetLayer, Place, Imageset } from "@wwtelescope/engine";
 import { applyImageSetLayerSetting } from "@wwtelescope/engine-helpers";
 
-import { drawSkyOverlays, initializeConstellationNames, makeAltAzGridText } from "./wwt-hacks";
+import { drawSkyOverlays, initializeConstellationNames, makeAltAzGridText, drawSpreadSheetLayer } from "./wwt-hacks";
 
 
 import {
@@ -695,6 +695,13 @@ export default defineComponent({
 
     this.waitForReady().then(() => {
 
+      // Unlike the other things we're hacking here,
+      // we aren't overwriting a method on a singleton instance (WWTControl)
+      // or a static method (Constellations, Grids)
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      SpreadSheetLayer.prototype.draw = drawSpreadSheetLayer;
+
       // This is just nice for hacking while developing
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
@@ -771,8 +778,9 @@ export default defineComponent({
         this.applyTableLayerSettings({
           id: layer.id.toString(),
           settings: [
-            ["scaleFactor", 30],
+            ["scaleFactor", 5],
             ["color", Color.fromHex(this.ephemerisColor)],
+            ["plotType", PlotTypes.point],
             //["sizeColumn", 3],
             ["opacity", 1]
           ]

--- a/green-comet/src/shims-wwt.d.ts
+++ b/green-comet/src/shims-wwt.d.ts
@@ -19,4 +19,10 @@ declare module "@wwtelescope/engine" {
     static create(x: number, y: number, z: number): Vector3d;
   }
 
+  export class Texture {}
+
+  export class PushPin {
+    static getPushPinTexture(pinId: number): Texture;
+  }
+
 }

--- a/green-comet/src/wwt-hacks.ts
+++ b/green-comet/src/wwt-hacks.ts
@@ -3,7 +3,12 @@
 
  /* eslint-disable */
 
-import { Color, Colors, Constellations, Coordinates, Grids, GlyphItem, GlyphCache, Rectangle, Settings, SpaceTimeController, Text3d, Text3dBatch, URLHelpers, Vector2d, Vector3d, WWTControl } from "@wwtelescope/engine";
+import {
+  Color, Colors, Constellations, Coordinates, Grids, GlyphItem,
+  GlyphCache, PushPin, Rectangle, Settings, SpaceTimeController,
+  SpreadSheetLayer, Text3d, Text3dBatch, URLHelpers, Vector2d,
+  Vector3d, WWTControl
+} from "@wwtelescope/engine";
 
 export function drawSkyOverlays() {
   if (Settings.get_active().get_showConstellationLabels()) {
@@ -60,4 +65,83 @@ export function makeAltAzGridText() {
       Grids._altAzTextBatch.add(new Text3d(Vector3d.create(...v), up, text, 75, 0.00018));
     });
   }
+}
+
+export function drawSpreadSheetLayer(renderContext, opacity, flat) {
+  var device = renderContext;
+  if (this.version !== this.lastVersion) {
+    this.cleanUp();
+  }
+  this.lastVersion = this.version;
+  if (this.bufferIsFlat !== flat) {
+    this.cleanUp();
+    this.bufferIsFlat = flat;
+  }
+  if (this.dirty) {
+    this.prepVertexBuffer(device, opacity);
+  }
+  var jNow = SpaceTimeController.get_jNow() - SpaceTimeController.utcToJulian(this.baseDate);
+  var adjustedScale = this.scaleFactor * 3;
+  if (flat && this.astronomical && (this._markerScale$1 === 1)) {
+    adjustedScale = (this.scaleFactor / (renderContext.viewCamera.zoom / 360));
+  }
+  if (this.triangleList2d != null) {
+    this.triangleList2d.decay = this.decay;
+    this.triangleList2d.sky = this.get_astronomical();
+    this.triangleList2d.timeSeries = this.timeSeries;
+    this.triangleList2d.jNow = jNow;
+    this.triangleList2d.draw(renderContext, opacity * this.get_opacity(), 1);
+  }
+  if (this.triangleList != null) {
+    this.triangleList.decay = this.decay;
+    this.triangleList.sky = this.get_astronomical();
+    this.triangleList.timeSeries = this.timeSeries;
+    this.triangleList.jNow = jNow;
+    this.triangleList.draw(renderContext, opacity * this.get_opacity(), 1);
+  }
+  if (this.pointList != null) {
+    this.pointList.depthBuffered = false;
+    this.pointList.showFarSide = this.get_showFarSide();
+    this.pointList.decay = (this.timeSeries) ? this.decay : 0;
+    this.pointList.sky = this.get_astronomical();
+    this.pointList.timeSeries = this.timeSeries;
+    this.pointList.jNow = jNow;
+    this.pointList.scale = (this._markerScale$1 === 1) ? adjustedScale : -adjustedScale;
+    switch (this._plotType$1) {
+      case 0:
+        this.pointList.draw(renderContext, opacity * this.get_opacity(), false);
+        break;
+      case 2:
+        this.pointList.drawTextured(renderContext, SpreadSheetLayer.get__circleTexture$1().texture2d, opacity * this.get_opacity());
+        break;
+      case 1:
+        this.pointList.drawTextured(renderContext, PushPin.getPushPinTexture(19), opacity * this.get_opacity());
+        break;
+      case 3:
+        this.pointList.drawTextured(renderContext, PushPin.getPushPinTexture(35), opacity * this.get_opacity());
+        break;
+      case 5:
+      case 4:
+        this.pointList.drawTextured(renderContext, PushPin.getPushPinTexture(this._markerIndex$1), opacity * this.get_opacity());
+        break;
+      default:
+        break;
+    }
+  }
+  if (this.lineList != null) {
+    this.lineList.sky = this.get_astronomical();
+    this.lineList.decay = this.decay;
+    this.lineList.timeSeries = this.timeSeries;
+    this.lineList.jNow = jNow;
+    this.lineList.drawLines(renderContext, opacity * this.get_opacity());
+  }
+  if (this.lineList2d != null) {
+    this.lineList2d.sky = this.get_astronomical();
+    this.lineList2d.decay = this.decay;
+    this.lineList2d.timeSeries = this.timeSeries;
+    this.lineList2d.showFarSide = this.get_showFarSide();
+    this.lineList2d.jNow = jNow;
+    this.lineList2d.drawLines(renderContext, opacity * this.get_opacity());
+  }
+  return true;
 }


### PR DESCRIPTION
This PR adds one more hack to the green comet story, letting us use the correct marker for the point and square plot types.

Note that the sorts of hacks we've done for this story won't be necessary in the future; functionality to change sky overlay settings as well as to use the correct plot type sprites have been added into the web engine.