### PR TITLE
Make opacity changes consistent & connect time slider to select folder-view

### DIFF
--- a/green-comet/src/C2022E3.vue
+++ b/green-comet/src/C2022E3.vue
@@ -53,7 +53,8 @@
         class="folder-view"
         sliders
         expandable
-        :thumbnails="false"
+        :thumbnails="true"
+        :open="mobile ? false : true"
         :root-folder="imagesetFolder"
         :wwt-namespace="wwtNamespace"
         flex-direction="column"
@@ -2170,8 +2171,8 @@ input[type="range"] {
     -webkit-appearance: inherit;
     -moz-appearance: inherit;
     appearance: inherit;
-    margin: 5px;
-    --track-height: 0.3em;
+    margin: 2px;
+    --track-height: 0.7em;
     --thumb-radius: 0.7em;
     --thumb-color: rgba(205, 54, 157  , 1);
     --track-color: rgba(4, 147, 214, 0.7);

--- a/green-comet/src/C2022E3.vue
+++ b/green-comet/src/C2022E3.vue
@@ -1066,7 +1066,6 @@ export default defineComponent({
     },
     
     onItemSelected(place: Place) {
-      console.log("onItemSelected", place.get_name());
       const iset = place.get_studyImageset() ?? place.get_backgroundImageset();
       if (iset == null) { return; }
       const layer = this.imagesetLayers[iset.get_name()];
@@ -1089,7 +1088,6 @@ export default defineComponent({
     },
 
     updateImageOpacity(place: Place, opacity: number) {
-      console.log('updateImageOpacity')
       const iset = place.get_studyImageset() ?? place.get_backgroundImageset();
       if (iset == null) { return; }
       const layer = this.imagesetLayers[iset.get_name()];
@@ -1104,7 +1102,6 @@ export default defineComponent({
       const iset = place.get_studyImageset() ?? place.get_backgroundImageset();
       if (iset == null) { return; } 
       const iname = iset.get_name()
-      console.log('onToggle', iname, checked, '')
       this.setLayerOpacityForImageSet(iname, checked ? 1 : 0);
     },
     
@@ -1460,7 +1457,6 @@ export default defineComponent({
     },
 
     setLayerOpacityForImageSet(name: string, opacity: number, setting_opacity_from_ui=false) {
-      console.log(`setLayerOpacityForImageSet(${name}, ${opacity})`)
       const layer = this.imagesetLayers[name]
       if (layer != null) {
         // update the image opacity in the WWT control
@@ -1470,25 +1466,8 @@ export default defineComponent({
         if (!setting_opacity_from_ui) {
           const selector = `#items div.item[title='${name}'] input.opacity-range[type='range']`
           const el = (document.querySelector(selector) as HTMLInputElement)
-          console.log(selector, el)
           if (el != null) {
-            console.log(`setting slider value to ${opacity * 100}`)
             el.value = `${opacity * 100}`
-          }
-        }
-
-        const toggle_selector = `#items input[type='checkbox'][title='${name}']`
-        const el2 = (document.querySelector(toggle_selector) as HTMLInputElement)
-        // truth table: opacity == 0 and el.checked == false => do nothing
-        // truth table: opacity == 0 and el.checked == true => set el.checked = false
-        // truth table: opacity > 0 and el.checked == false => set el.checked = true
-        // truth table: opacity > 0 and el.checked == true => do nothing
-        if (el2 != null) {
-          console.log(`setting checkbox value to ${opacity > 0}`)
-          if (opacity == 0 && el2.checked) {
-            el2.checked = false
-          } else if (opacity > 0 && !el2.checked) {
-            el2.checked = true
           }
         }
         
@@ -1496,7 +1475,6 @@ export default defineComponent({
     },
     
     showImageForDateTime(date: Date) {
-      console.log('showImageForDateTime', date)
       const name = this.matchImageSetName(date)
       const imageset_names = Object.keys(this.imagesetLayers)
       imageset_names.forEach((iname: string) => {
@@ -1527,7 +1505,6 @@ export default defineComponent({
     },
 
     updateForDateTime() {
-      console.log('updateForDateTime', this.dateTime)
       this.setTime(this.dateTime);
       this.updateHorizon(this.dateTime);
       this.showImageForDateTime(this.dateTime);
@@ -1536,7 +1513,6 @@ export default defineComponent({
     },
 
     updateHorizon(when: Date | null = null) {
-      console.log('updateHorizon', when)
       if (this.showHorizon) {
         this.createHorizon(when);
       } else {
@@ -1597,7 +1573,6 @@ export default defineComponent({
       // });
     },
     selectedDate(_date: Date) {
-      console.log('selectedDate (watcher)', _date)
       this.updateForDateTime();
     },
     showLocationSelector(show: boolean) {

--- a/green-comet/src/C2022E3.vue
+++ b/green-comet/src/C2022E3.vue
@@ -53,7 +53,7 @@
         class="folder-view"
         sliders
         expandable
-        :thumbnails="false"
+        :thumbnails="true"
         :open="mobile ? false : true"
         :root-folder="imagesetFolder"
         :wwt-namespace="wwtNamespace"
@@ -1579,11 +1579,11 @@ html {
   overflow: hidden;
 
   ::-webkit-scrollbar {
-    display: none;
+    // display: none;
   }
-
+  
   -ms-overflow-style: none;
-  scrollbar-width: none;
+  // scrollbar-width: none;
 }
 
 body {

--- a/green-comet/src/C2022E3.vue
+++ b/green-comet/src/C2022E3.vue
@@ -54,7 +54,7 @@
         sliders
         expandable
         :thumbnails="true"
-        :open="mobile ? false : true"
+        :open="mobile ? true : true"
         :root-folder="imagesetFolder"
         :wwt-namespace="wwtNamespace"
         flex-direction="column"

--- a/green-comet/src/C2022E3.vue
+++ b/green-comet/src/C2022E3.vue
@@ -53,7 +53,7 @@
         class="folder-view"
         sliders
         expandable
-        :thumbnails="true"
+        :thumbnails="false"
         :open="mobile ? false : true"
         :root-folder="imagesetFolder"
         :wwt-namespace="wwtNamespace"

--- a/green-comet/src/C2022E3.vue
+++ b/green-comet/src/C2022E3.vue
@@ -57,6 +57,7 @@
         :open="mobile ? true : true"
         :root-folder="imagesetFolder"
         :wwt-namespace="wwtNamespace"
+        :incomingItemSelect="incomingItemSelect"
         flex-direction="column"
         @select="onItemSelected"
         @opacity="updateImageOpacity"
@@ -520,7 +521,7 @@ import { csvFormatRows, csvParse } from "d3-dsv";
 
 import { distance, fmtDegLat, fmtDegLon, fmtHours } from "@wwtelescope/astro";
 import { Color, Constellations, Folder, Grids, LayerManager, Poly, RenderContext, Settings, SpreadSheetLayer, WWTControl } from "@wwtelescope/engine";
-import { ImageSetType, MarkerScales, PlotTypes } from "@wwtelescope/engine-types";
+import { ImageSetType, MarkerScales, PlotTypes, Thumbnail } from "@wwtelescope/engine-types";
 
 import L, { LeafletMouseEvent, Map } from "leaflet";
 import { MiniDSBase, BackgroundImageset, skyBackgroundImagesets } from "@minids/common"
@@ -666,6 +667,8 @@ export default defineComponent({
       cometColor: "#04D6B0",
       todayColor: "#D60493",
 
+      incomingItemSelect: null as Thumbnail | null,
+      
       sheet: null as SheetType,
       showMapTooltip: false,
       showTextTooltip: false,
@@ -1482,6 +1485,14 @@ export default defineComponent({
           this.setLayerOpacityForImageSet(iname, 0)
         } else {
           this.setLayerOpacityForImageSet(iname, 1)
+          // need to get the Place object for the image set and use it to set the view
+          if (this.imagesetFolder != null) {
+            const places = this.imagesetFolder.get_children()
+            if (places != null) {
+              const place = places.filter((place) => place.get_name() == iname)
+              this.incomingItemSelect = place[0]
+            }
+          }
           // const iset = this.wwtControl.getImagesetByName(iname)
           // if (iset == null) { return; }
           // this.gotoRADecZoom({

--- a/green-comet/src/C2022E3.vue
+++ b/green-comet/src/C2022E3.vue
@@ -2172,11 +2172,23 @@ input[type="range"] {
     -moz-appearance: inherit;
     appearance: inherit;
     margin: 2px;
-    --track-height: 0.7em;
-    --thumb-radius: 0.7em;
-    --thumb-color: rgba(205, 54, 157  , 1);
-    --track-color: rgba(4, 147, 214, 0.7);
-    --thumb-border: 1px solid #899499;
+    --track-height: 1em;
+    --thumb-radius: 0.8em;
+    --thumb-color: rgba(205, 54, 157  , 0.7);
+    // --thumb-color: #444;
+    --track-color: rgba(4, 147, 214, .1);
+    // --thumb-border: 1px solid #899499;
+    --thumb-border-width: 1px;
+    --thumb-border: var(--thumb-border-width) solid rgb(255, 255, 255);
+    --track-border-width: 1px;
+    --track-border: var(--track-border-width) solid rgba(4, 147, 214, 1);
+    --thumb-margin-top: calc((var(--track-height) - 2*var(--track-border-width)) / 2 - (var(--thumb-radius)) / 2);
+    
+    &:hover {
+      opacity: 1;
+      --track-color: rgba(217, 234, 242,0.2);
+      --thumb-color: rgba(205, 54, 157  , 1);
+    }
   }
   
   
@@ -2187,7 +2199,7 @@ input[type="range"] {
       appearance: inherit;
     width: var(--thumb-radius);
     height: var(--thumb-radius);
-    margin-top: calc(var(--track-height) / 2 - var(--thumb-radius) / 2);
+    margin-top: var(--thumb-margin-top);
     border-radius: 50%;
     background: var(--thumb-color);
     border: var(--thumb-border);
@@ -2201,7 +2213,7 @@ input[type="range"] {
     appearance: inherit;
     width: var(--thumb-radius);
     height: var(--thumb-radius);
-    margin-top: calc(var(--track-height) / 2 - var(--thumb-radius) / 2);
+    margin-top: var(--thumb-margin-top);
     border-radius: 50%;
     background: var(--thumb-color);
     cursor: pointer;
@@ -2212,8 +2224,10 @@ input[type="range"] {
     background: var(--track-color);
     /* outline: 1px solid white; */
     border-radius: calc(var(--track-height) / 2);
+    border: var(--track-border);
     height: var(--track-height);
     margin-top: 0;
+    padding: 0 calc((var(--track-height) - var(--thumb-radius))/2);
   }
   
   
@@ -2221,8 +2235,10 @@ input[type="range"]::-moz-range-track {
     background: var(--track-color);
     /* outline: 1px solid white; */
     border-radius: calc(var(--track-height) / 2);
+    border: var(--track-border);
     height:var(--track-height);
     margin-top: 0;
+    padding: 0 calc((var(--track-height) - var(--thumb-radius))/2);
   }
   
 #sliderlabel {

--- a/green-comet/src/FolderView.vue
+++ b/green-comet/src/FolderView.vue
@@ -13,6 +13,9 @@
         <img
           src="https://github.com/cosmicds/cds-website/raw/main/public/comet_c2022-e3/thumbnails/694_2022E3_14_01_23.jpg"
         />
+        <div class="item-name">
+          Press <span v-if="thumbnails">image</span><span v-else>date</span> to go to image
+        </div>
         <div class="overlay">
           <font-awesome-icon
             icon="images"
@@ -30,7 +33,7 @@
           v-if="items !== null && expanded"
         >
           <div
-            :class="['button-38','bordered', 'item', lastSelectedItem === item ? 'selected' : '']"
+            :class="['bordered', 'item', lastSelectedItem === item ? 'selected' : '']"
             v-for="item of items"
             :key="item.get_name()"
             :title="item.get_name()"
@@ -172,7 +175,7 @@ export default defineComponent({
   overflow-y: hidden;
   pointer-events: auto;
   background: black;
-  outline: 1px solid rgb(4, 214, 175);
+  // outline: 1px solid rgb(4, 214, 175);
   padding: 3px;
   border-radius: 2px;
   &::-webkit-scrollbar {
@@ -193,7 +196,6 @@ export default defineComponent({
 #items {
   height: 100%;
   overflow-y: auto;
-  // add wide radial gradient to the background
 }
 
 .item {
@@ -210,7 +212,6 @@ export default defineComponent({
     object-fit: cover;
     border-radius: 2px;
   }
-
 
   & input[type=range] {
     width: calc(min(12vh, 100px));
@@ -231,8 +232,8 @@ export default defineComponent({
 
 .bordered {
   border: 1px solid rgb(68, 68, 68);
-  background-color: rgba(68, 68, 68, 0.25);
-  border-radius: 2px;
+  background-color: rgba(68, 68, 68, 0.5);
+  border-radius: 5px;
 }
 
 #expand-row {
@@ -252,8 +253,8 @@ export default defineComponent({
 }
 
 .overlay {
-   position:absolute;
-   top:0;
-   left:75%;
+  position:absolute;
+  top:0;
+  left:75%;
 }
 </style>

--- a/green-comet/src/FolderView.vue
+++ b/green-comet/src/FolderView.vue
@@ -104,7 +104,13 @@ export default defineComponent({
     open: {
       type: Boolean,
       default: false
+    },
+
+    incomingItemSelect: {
+      type: Object as PropType<Thumbnail>,
+      default: null
     }
+    
   },
 
   data() {
@@ -170,6 +176,14 @@ export default defineComponent({
       }
     },
   },
+
+  watch: {
+    incomingItemSelect() {
+      if (this.incomingItemSelect != null) {
+        this.lastSelectedItem = this.incomingItemSelect;
+      }
+    }
+  }
 });
 </script>
 

--- a/green-comet/src/FolderView.vue
+++ b/green-comet/src/FolderView.vue
@@ -172,30 +172,33 @@ export default defineComponent({
   flex-direction: var(--flex-direction);
   width: auto;
   overflow-x: auto;
-  overflow-y: hidden;
+  overflow-y: auto;
   pointer-events: auto;
   background: rgba(0, 0, 0, 0.5);
   // outline: 1px solid rgb(4, 214, 175);
   padding: 3px;
   border-radius: 2px;
-  &::-webkit-scrollbar {
-    padding: 1px;
-    height: 3px;
-  }
-  &::-webkit-scrollbar-track {
-    background: black;
-  }
-  &::-webkit-scrollbar-thumb {
-    background: rgba(4, 129, 187, 0.5);
-    border-radius: 2px;
-  }
-  //width: 100%;
-  //justify-content: space-around;
 }
 
 #items {
   height: 100%;
   overflow-y: auto;
+  &::-webkit-scrollbar {
+    -webkit-appearance: none;
+    width: 15px;
+  }
+  &::-webkit-scrollbar-track {
+    background: rgb(0, 0, 0,0.5);
+    // border: 5px solid red;
+  }
+  &::-webkit-scrollbar-thumb {
+    background: rgba(100, 100, 100, 0.5);
+    width: 10px;
+    border: 3px solid black;
+    border-radius: 10px;
+  }
+  //width: 100%;
+  //justify-content: space-around;
 }
 
 .item {

--- a/green-comet/src/FolderView.vue
+++ b/green-comet/src/FolderView.vue
@@ -174,7 +174,7 @@ export default defineComponent({
   overflow-x: auto;
   overflow-y: hidden;
   pointer-events: auto;
-  background: black;
+  background: rgba(0, 0, 0, 0.5);
   // outline: 1px solid rgb(4, 214, 175);
   padding: 3px;
   border-radius: 2px;
@@ -215,6 +215,8 @@ export default defineComponent({
 
   & input[type=range] {
     width: calc(min(12vh, 100px));
+    // width: 90%;
+    // margin: 0 auto;
   }
   &.selected {
     border: 1px solid #D60493;
@@ -232,7 +234,7 @@ export default defineComponent({
 
 .bordered {
   border: 1px solid rgb(68, 68, 68);
-  background-color: rgba(68, 68, 68, 0.5);
+  // background-color: rgba(68, 68, 68, 0.5);
   border-radius: 5px;
 }
 

--- a/green-comet/src/FolderView.vue
+++ b/green-comet/src/FolderView.vue
@@ -51,7 +51,6 @@
             >
               {{item.get_name()}}
             </div>
-            <div class="slider-container">
             <input
               v-if="sliders"
               class="opacity-range"
@@ -59,18 +58,6 @@
               value="0"
               @input="(e) => onSliderInputChanged(e, item)"
             />
-            
-
-              <label class="switch">
-                <input 
-                  type="checkbox"
-                  :title="item.get_name()"
-                  @change="(e) => onToggleImage(e, item)"
-                  >
-                <span class="slider"></span>
-              </label> 
-            </div>
-
           </div>
         </div>
       </div>
@@ -280,74 +267,4 @@ export default defineComponent({
   top:0;
   left:75%;
 }
-
-.slider-container {
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.5em;
-  
-  
-}
-.switch {
-  // moving toggle
-  --toggle-size: 0.77em;
-  --slider-height: calc(var(--toggle-size) * 1.3);
-  --toggle-bottom-gap: calc((var(--slider-height) - var(--toggle-size))/2);
-  --toggle-left-gap: var(--toggle-bottom-gap);
-  --slider-width: calc(2*(var(--toggle-left-gap) + var(--toggle-size)));
-  --translateX: var(--toggle-size);
-
-  position: relative;
-  display: flex;
-  width: var(--slider-width);
-  height: var(--slider-height);
-}
-
-.switch input { 
-  visibility: hidden;
-}
-
-.slider {
-  position: absolute;
-  cursor: pointer;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: #ccc;
-  -webkit-transition: .4s;
-  transition: .4s;
-  border-radius: var(--slider-height);
-}
-
-.slider:before {
-  position: absolute;
-  content: "";
-  height: var(--toggle-size);
-  width: var(--toggle-size);
-  left: var(--toggle-left-gap);
-  bottom: var(--toggle-bottom-gap);
-  background-color: white;
-  -webkit-transition: .4s;
-  transition: .4s;
-  border-radius: 50%;
-}
-
-input:checked + .slider {
-  background-color: #2196F3;
-}
-
-input:focus + .slider {
-  box-shadow: 0 0 1px #2196F3;
-}
-
-input:checked + .slider:before {
-  -webkit-transform: translateX(var(--translateX));
-  -ms-transform: translateX(var(--translateX));
-  transform: translateX(var(--translateX));
-}
-
-
 </style>

--- a/green-comet/src/FolderView.vue
+++ b/green-comet/src/FolderView.vue
@@ -51,6 +51,7 @@
             >
               {{item.get_name()}}
             </div>
+            <div class="slider-container">
             <input
               v-if="sliders"
               class="opacity-range"
@@ -68,6 +69,7 @@
                   >
                 <span class="slider"></span>
               </label> 
+            </div>
 
           </div>
         </div>
@@ -279,26 +281,32 @@ export default defineComponent({
   left:75%;
 }
 
-
-
+.slider-container {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5em;
+  
+  
+}
 .switch {
-  --toggle-size: 1em;
+  // moving toggle
+  --toggle-size: 0.77em;
   --slider-height: calc(var(--toggle-size) * 1.3);
   --toggle-bottom-gap: calc((var(--slider-height) - var(--toggle-size))/2);
   --toggle-left-gap: var(--toggle-bottom-gap);
   --slider-width: calc(2*(var(--toggle-left-gap) + var(--toggle-size)));
   --translateX: var(--toggle-size);
-  
+
   position: relative;
-  display: inline-block;
+  display: flex;
   width: var(--slider-width);
   height: var(--slider-height);
 }
 
 .switch input { 
-  opacity: 0;
-  width: 0;
-  height: 0;
+  visibility: hidden;
 }
 
 .slider {

--- a/green-comet/src/FolderView.vue
+++ b/green-comet/src/FolderView.vue
@@ -59,17 +59,16 @@
               @input="(e) => onSliderInputChanged(e, item)"
             />
             
-            <span class="toggle-switch">
+
               <label class="switch">
                 <input 
                   type="checkbox"
                   :title="item.get_name()"
                   @change="(e) => onToggleImage(e, item)"
-                  
                   >
                 <span class="slider"></span>
-              </label>
-            </span>
+              </label> 
+
           </div>
         </div>
       </div>
@@ -280,68 +279,67 @@ export default defineComponent({
   left:75%;
 }
 
-// Create a custom toggle switch
 
-span.toggle-switch {
+
+.switch {
+  --toggle-size: 1em;
+  --slider-height: calc(var(--toggle-size) * 1.3);
+  --toggle-bottom-gap: calc((var(--slider-height) - var(--toggle-size))/2);
+  --toggle-left-gap: var(--toggle-bottom-gap);
+  --slider-width: calc(2*(var(--toggle-left-gap) + var(--toggle-size)));
+  --translateX: var(--toggle-size);
+  
   position: relative;
   display: inline-block;
-  
-  --size: 1em;
-  --slider-width: calc(2.5 * var(--size));
-  --slider-height: calc(1.5 * var(--size));
   width: var(--slider-width);
   height: var(--slider-height);
-  margin: auto;
-  
-  label.switch {
-    position: absolute;
-      input {
-        visibility: hidden;
-      }
-  }
-
-  /* The slider */
-  .slider {
-    position: absolute;
-    cursor: pointer;
-    top: 0px;
-    left: 0;
-    bottom: 0;
-    height: var(--slider-height);
-    width: var(--slider-width);
-    background-color: #ccc;
-    -webkit-transition: .4s;
-    transition: .4s;
-    border: 1px solid blue;
-    border-radius: calc(var(--slider-height)/2);
-  }
-
-  .slider:before {
-    position: absolute;
-    content: "";
-    height: var(--size);
-    width: var(--size);
-    left: 1px;
-    margin-top: calc(var(--slider-height)/2 - var(--size)/2);
-    // bottom: 0px;
-    background-color: white;
-    -webkit-transition: .4s;
-    transition: .4s;
-    border-radius: calc(var(--size));
-  }
-
-  /* display-item box styles */
-  input:checked + .slider {
-    background-color: #2196F3;
-  }
-  input:focus + .slider {
-    box-shadow: 0 0 1px #2196F3;
-  }
-
-  input:checked + .slider:before {
-    -webkit-transform: translateX(var(--size));
-    -ms-transform: translateX(var(--size));
-    transform: translateX(var(--size));
-  }
 }
+
+.switch input { 
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ccc;
+  -webkit-transition: .4s;
+  transition: .4s;
+  border-radius: var(--slider-height);
+}
+
+.slider:before {
+  position: absolute;
+  content: "";
+  height: var(--toggle-size);
+  width: var(--toggle-size);
+  left: var(--toggle-left-gap);
+  bottom: var(--toggle-bottom-gap);
+  background-color: white;
+  -webkit-transition: .4s;
+  transition: .4s;
+  border-radius: 50%;
+}
+
+input:checked + .slider {
+  background-color: #2196F3;
+}
+
+input:focus + .slider {
+  box-shadow: 0 0 1px #2196F3;
+}
+
+input:checked + .slider:before {
+  -webkit-transform: translateX(var(--translateX));
+  -ms-transform: translateX(var(--translateX));
+  transform: translateX(var(--translateX));
+}
+
+
 </style>

--- a/green-comet/src/FolderView.vue
+++ b/green-comet/src/FolderView.vue
@@ -37,12 +37,12 @@
             v-for="item of items"
             :key="item.get_name()"
             :title="item.get_name()"
-            @click="() => selectItem(item)"
           >
             <img
               v-if="thumbnails"
               :src="item.get_thumbnailUrl()"
               :alt="item.get_name()"
+              @click="() => selectItem(item)"
             />
             <div
               class="item-name"
@@ -58,6 +58,18 @@
               value="0"
               @input="(e) => onSliderInputChanged(e, item)"
             />
+            
+            <span class="toggle-switch">
+              <label class="switch">
+                <input 
+                  type="checkbox"
+                  :title="item.get_name()"
+                  @change="(e) => onToggleImage(e, item)"
+                  
+                  >
+                <span class="slider"></span>
+              </label>
+            </span>
           </div>
         </div>
       </div>
@@ -136,6 +148,7 @@ export default defineComponent({
       return item instanceof Imageset;
     },
     selectItem(item: Thumbnail): void {
+      console.log("FolderView: item selected")
       this.lastSelectedItem = item;
       if (item instanceof Folder || item instanceof FolderUp) {
         this.items = item.get_children() ?? [];
@@ -144,7 +157,13 @@ export default defineComponent({
       }
     },
     onSliderInputChanged(e: Event, item: Thumbnail) {
+      console.log("FolderView: slider changed")
       this.$emit('opacity', item, (e.target as HTMLInputElement).value)
+    },
+
+    onToggleImage(e: Event, item: Thumbnail) {
+      console.log("FolderView: toggled")
+      this.$emit('toggle', item, (e.target as HTMLInputElement).checked)
     }
   },
 
@@ -218,8 +237,6 @@ export default defineComponent({
 
   & input[type=range] {
     width: calc(min(12vh, 100px));
-    // width: 90%;
-    // margin: 0 auto;
   }
   &.selected {
     border: 1px solid #D60493;
@@ -261,5 +278,70 @@ export default defineComponent({
   position:absolute;
   top:0;
   left:75%;
+}
+
+// Create a custom toggle switch
+
+span.toggle-switch {
+  position: relative;
+  display: inline-block;
+  
+  --size: 1em;
+  --slider-width: calc(2.5 * var(--size));
+  --slider-height: calc(1.5 * var(--size));
+  width: var(--slider-width);
+  height: var(--slider-height);
+  margin: auto;
+  
+  label.switch {
+    position: absolute;
+      input {
+        visibility: hidden;
+      }
+  }
+
+  /* The slider */
+  .slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0px;
+    left: 0;
+    bottom: 0;
+    height: var(--slider-height);
+    width: var(--slider-width);
+    background-color: #ccc;
+    -webkit-transition: .4s;
+    transition: .4s;
+    border: 1px solid blue;
+    border-radius: calc(var(--slider-height)/2);
+  }
+
+  .slider:before {
+    position: absolute;
+    content: "";
+    height: var(--size);
+    width: var(--size);
+    left: 1px;
+    margin-top: calc(var(--slider-height)/2 - var(--size)/2);
+    // bottom: 0px;
+    background-color: white;
+    -webkit-transition: .4s;
+    transition: .4s;
+    border-radius: calc(var(--size));
+  }
+
+  /* display-item box styles */
+  input:checked + .slider {
+    background-color: #2196F3;
+  }
+  input:focus + .slider {
+    box-shadow: 0 0 1px #2196F3;
+  }
+
+  input:checked + .slider:before {
+    -webkit-transform: translateX(var(--size));
+    -ms-transform: translateX(var(--size));
+    transform: translateX(var(--size));
+  }
 }
 </style>

--- a/green-comet/src/FolderView.vue
+++ b/green-comet/src/FolderView.vue
@@ -30,10 +30,11 @@
           v-if="items !== null && expanded"
         >
           <div
-            :class="['bordered', 'item', lastSelectedItem === item ? 'selected' : '']"
+            :class="['button-38','bordered', 'item', lastSelectedItem === item ? 'selected' : '']"
             v-for="item of items"
             :key="item.get_name()"
             :title="item.get_name()"
+            @click="() => selectItem(item)"
           >
             <img
               v-if="thumbnails"
@@ -42,6 +43,7 @@
             />
             <div
               class="item-name"
+              :class="['thumbnail']"
               @click="() => selectItem(item)"
             >
               {{item.get_name()}}
@@ -96,14 +98,18 @@ export default defineComponent({
       type: Boolean,
       default: true
     },
+    open: {
+      type: Boolean,
+      default: false
+    }
   },
 
   data() {
     return {
       items: [] as Thumbnail[],
       lastSelectedItem: null as Thumbnail | null,
-      opacities: {} as Record<string,number>,
-      expanded: true
+      opacities: {} as Record<string, number>,
+      expanded: this.open
     }
   },
 
@@ -145,6 +151,14 @@ export default defineComponent({
         "--flex-direction": this.flexDirection
       }
     },
+
+    isMobile() {
+      if (/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)) {
+        return true
+      } else {
+        return false
+      }
+    },
   },
 });
 </script>
@@ -158,6 +172,9 @@ export default defineComponent({
   overflow-y: hidden;
   pointer-events: auto;
   background: black;
+  outline: 1px solid rgb(4, 214, 175);
+  padding: 3px;
+  border-radius: 2px;
   &::-webkit-scrollbar {
     padding: 1px;
     height: 3px;
@@ -176,6 +193,7 @@ export default defineComponent({
 #items {
   height: 100%;
   overflow-y: auto;
+  // add wide radial gradient to the background
 }
 
 .item {
@@ -185,12 +203,14 @@ export default defineComponent({
   width: 100%;
   cursor: pointer;
   pointer-events: auto;
+  margin: .35em 0;
   & img {
     width: 100%;
     height: ~"min(45px, 7.5vw)";
     object-fit: cover;
     border-radius: 2px;
   }
+
 
   & input[type=range] {
     width: calc(min(12vh, 100px));
@@ -210,7 +230,8 @@ export default defineComponent({
 }
 
 .bordered {
-  border: 1px solid #444;
+  border: 1px solid rgb(68, 68, 68);
+  background-color: rgba(68, 68, 68, 0.25);
   border-radius: 2px;
 }
 

--- a/green-comet/src/main.ts
+++ b/green-comet/src/main.ts
@@ -24,8 +24,7 @@ import {
   faTimes,
   faVideo,
   faCameraRetro,
-  faImages,
-  faHandPointer
+  faImages
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 
@@ -38,7 +37,6 @@ library.add(faChevronUp);
 library.add(faCameraRetro);
 library.add(faImages);
 library.add(faGear);
-library.add(faHandPointer);
 
 import { WWTComponent, wwtPinia } from "@wwtelescope/engine-pinia";
 

--- a/green-comet/src/main.ts
+++ b/green-comet/src/main.ts
@@ -24,7 +24,8 @@ import {
   faTimes,
   faVideo,
   faCameraRetro,
-  faImages
+  faImages,
+  faHandPointer
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 
@@ -37,6 +38,7 @@ library.add(faChevronUp);
 library.add(faCameraRetro);
 library.add(faImages);
 library.add(faGear);
+library.add(faHandPointer);
 
 import { WWTComponent, wwtPinia } from "@wwtelescope/engine-pinia";
 


### PR DESCRIPTION
This PR adds a layer toggle and makes sure opacity sliders and toggles are all updated when ever a layer is changed. This is done by piping all changes through a new `setLayerOpacityForImageSet` where the DOM elements are selected and changed. This keeps code tidy and makes it easier to separate out features. 

