### PR TITLE
Allow imageset layers to be above spreadsheet layers

### DIFF
--- a/green-comet/src/C2022E3.vue
+++ b/green-comet/src/C2022E3.vue
@@ -1148,7 +1148,6 @@ export default defineComponent({
         latitudeRad: e.latlng.lat * D2R,
         longitudeRad: e.latlng.lng * D2R
       };
-      console.log('In onMapSelect: ', this.location);
     },
 
     circleForLocation(latDeg: number, lonDeg: number): L.Circle<any> {

--- a/green-comet/src/C2022E3.vue
+++ b/green-comet/src/C2022E3.vue
@@ -526,14 +526,13 @@ import { MiniDSBase, BackgroundImageset, skyBackgroundImagesets } from "@minids/
 import { ImageSetLayer, Place, Imageset } from "@wwtelescope/engine";
 import { applyImageSetLayerSetting } from "@wwtelescope/engine-helpers";
 
-import { drawSkyOverlays, initializeConstellationNames, makeAltAzGridText, drawSpreadSheetLayer } from "./wwt-hacks";
+import { drawSkyOverlays, initializeConstellationNames, makeAltAzGridText, drawSpreadSheetLayer, layerManagerDraw } from "./wwt-hacks";
 
 
 import {
   ephemerisFullWeeklyCsv,
   ephemeris2023DailyCsv
 } from "./data";
-import { Script } from 'vm';
 
 const D2R = Math.PI / 180;
 const R2D = 180 / Math.PI;
@@ -854,6 +853,10 @@ export default defineComponent({
       // @ts-ignore
       Constellations.initializeConstellationNames = initializeConstellationNames;
       Grids._makeAltAzGridText = makeAltAzGridText;
+
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      LayerManager._draw = layerManagerDraw;
 
       this.updateWWTLocation();
 

--- a/green-comet/src/wwt-hacks.ts
+++ b/green-comet/src/wwt-hacks.ts
@@ -167,8 +167,10 @@ export function layerManagerDraw(renderContext, opacity, astronomical, reference
     }
     renderContext.set_nominalRadius(thisMap.frame.meanRadius);
   }
+  //console.log("========");
   for (const layer of LayerManager.get_allMaps()[referenceFrame].layers) {
     if (layer.enabled) {
+      //console.log(layer);
       var layerStart = SpaceTimeController.utcToJulian(layer.get_startTime());
       var layerEnd = SpaceTimeController.utcToJulian(layer.get_endTime());
       var fadeIn = SpaceTimeController.utcToJulian(layer.get_startTime()) - ((layer.get_fadeType() === 1 || layer.get_fadeType() === 3) ? (layer.get_fadeSpan() / 864000000) : 0);

--- a/green-comet/src/wwt-hacks.ts
+++ b/green-comet/src/wwt-hacks.ts
@@ -4,9 +4,9 @@
  /* eslint-disable */
 
 import {
-  Color, Colors, Constellations, Coordinates, Grids, GlyphItem,
-  GlyphCache, PushPin, Rectangle, Settings, SpaceTimeController,
-  SpreadSheetLayer, Text3d, Text3dBatch, URLHelpers, Vector2d,
+  Color, Colors, Constellations, Coordinates, Grids,
+  LayerManager, LayerMap, PushPin, Settings, SpaceTimeController,
+  SpreadSheetLayer, Text3d, Text3dBatch, URLHelpers,
   Vector3d, WWTControl
 } from "@wwtelescope/engine";
 
@@ -145,3 +145,48 @@ export function drawSpreadSheetLayer(renderContext, opacity, flat) {
   }
   return true;
 }
+
+export function layerManagerDraw(renderContext, opacity, astronomical, referenceFrame, nested, cosmos) {
+  if (!(referenceFrame in LayerManager.get_allMaps())) {
+    return;
+  }
+  var thisMap = LayerManager.get_allMaps()[referenceFrame];
+  if (!thisMap.enabled || (!thisMap.layers.length && !(thisMap.frame.showAsPoint || thisMap.frame.showOrbitPath))) {
+    return;
+  }
+  var matOld = renderContext.get_world();
+  var matOldNonRotating = renderContext.get_worldBaseNonRotating();
+  var oldNominalRadius = renderContext.get_nominalRadius();
+  if ((thisMap.frame.reference === 18 | thisMap.frame.reference === 18) === 1) {
+    thisMap.computeFrame(renderContext);
+    if (thisMap.frame.referenceFrameType !== 1 && thisMap.frame.referenceFrameType !== 2) {
+      renderContext.set_world(Matrix3d.multiplyMatrix(thisMap.frame.worldMatrix, renderContext.get_world()));
+    }
+    else {
+      renderContext.set_world(Matrix3d.multiplyMatrix(thisMap.frame.worldMatrix, renderContext.get_worldBaseNonRotating()));
+    }
+    renderContext.set_nominalRadius(thisMap.frame.meanRadius);
+  }
+  for (const layer of LayerManager.get_allMaps()[referenceFrame].layers) {
+    if (layer.enabled) {
+      var layerStart = SpaceTimeController.utcToJulian(layer.get_startTime());
+      var layerEnd = SpaceTimeController.utcToJulian(layer.get_endTime());
+      var fadeIn = SpaceTimeController.utcToJulian(layer.get_startTime()) - ((layer.get_fadeType() === 1 || layer.get_fadeType() === 3) ? (layer.get_fadeSpan() / 864000000) : 0);
+      var fadeOut = SpaceTimeController.utcToJulian(layer.get_endTime()) + ((layer.get_fadeType() === 2 || layer.get_fadeType() === 3) ? (layer.get_fadeSpan() / 864000000) : 0);
+      if (SpaceTimeController.get_jNow() > fadeIn && SpaceTimeController.get_jNow() < fadeOut) {
+        var fadeOpacity = 1;
+        if (SpaceTimeController.get_jNow() < layerStart) {
+          fadeOpacity = ((SpaceTimeController.get_jNow() - fadeIn) / (layer.get_fadeSpan() / 864000000));
+        }
+        if (SpaceTimeController.get_jNow() > layerEnd) {
+          fadeOpacity = ((fadeOut - SpaceTimeController.get_jNow()) / (layer.get_fadeSpan() / 864000000));
+        }
+        layer.set_astronomical(astronomical);
+        layer.draw(renderContext, opacity * fadeOpacity, cosmos);
+      }
+    }
+  }
+  renderContext.set_nominalRadius(oldNominalRadius);
+  renderContext.set_world(matOld);
+  renderContext.set_worldBaseNonRotating(matOldNonRotating);
+};


### PR DESCRIPTION
This PR hacks the layer manager's draw function to allow putting imageset layers above spreadsheet layers. The hacked draw function also trims out some other functionality (for displaying tours and nested reference frames) that we don't need here. As it's set up now, the images are in front of all of the spreadsheet layers, with the exception of the interpolated point layer.