### PR TITLE
Add two "Best View" buttons to control panel

### DIFF
--- a/green-comet/src/C2022E3.vue
+++ b/green-comet/src/C2022E3.vue
@@ -208,7 +208,7 @@
             <v-btn
               :color="cometColor"
               @click="() => updateViewForDate({
-                zoomDeg: 60
+                zoomDeg: 360
               })"
             >
               Best view for comet path


### PR DESCRIPTION
This PR adds two new buttons to the bottom-right control panel:

* One sets the FOV to 60 degrees and is centered on the currently selected date/time
* One set the FOV to 10 degrees and centers the view on the 12/18/2022 comet image (and changes the opacity of that image to 1)