### PR TITLE
Add linting step to CI

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,18 +14,39 @@ module.exports = {
   ],
   rules: {
     "no-unused-vars": [
-      "warn", {
+      "error", {
         "args": "all",
         "argsIgnorePattern": "^_",
         "varsIgnorePattern": "^_"
       }
     ],
+    "semi": "off",
+    "@typescript-eslint/naming-convention": [
+      "error", {
+        selector: ["variable"],
+        format: ["camelCase"]
+      },
+      {
+        selector: ["variable"],
+        modifiers: ["global", "const"],
+        format: ["camelCase", "UPPER_CASE"]
+      },
+      {
+        selector: ["function"],
+        format: ["camelCase"]
+      },
+      {
+        selector: "typeLike",
+        format: ["PascalCase"]
+      }
+    ],
     "@typescript-eslint/no-unused-vars": [
-      "warn", {
+      "error", {
         "args": "all",
         "argsIgnorePattern": "^_",
         "varsIgnorePattern": "^_"
       }
-    ]
+    ],
+    "@typescript-eslint/semi": "error"
   }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,6 +13,7 @@ module.exports = {
     'plugin:@typescript-eslint/recommended'
   ],
   rules: {
+    "indent": ["error", 2],
     "no-unused-vars": [
       "error", {
         "args": "all",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,31 +14,36 @@ module.exports = {
   ],
   rules: {
     "indent": ["error", 2],
-    "no-unused-vars": [
-      "error", {
-        "args": "all",
-        "argsIgnorePattern": "^_",
-        "varsIgnorePattern": "^_"
-      }
-    ],
-    "semi": "off",
     "@typescript-eslint/naming-convention": [
       "error", {
-        selector: ["variable"],
-        format: ["camelCase"]
+        selector: ["variable", "memberLike", "function"],
+        format: ["camelCase"],
+        leadingUnderscore: "allow"
       },
       {
         selector: ["variable"],
         modifiers: ["global", "const"],
-        format: ["camelCase", "UPPER_CASE"]
-      },
-      {
-        selector: ["function"],
-        format: ["camelCase"]
+        format: ["camelCase", "UPPER_CASE"],
+        leadingUnderscore: "allow"
       },
       {
         selector: "typeLike",
-        format: ["PascalCase"]
+        format: ["PascalCase"],
+        leadingUnderscore: "allow"
+      },
+      {
+        selector: [
+          "classProperty",
+          "objectLiteralProperty",
+          "typeProperty",
+          "classMethod",
+          "objectLiteralMethod",
+          "typeMethod",
+          "accessor",
+          "enumMember"
+        ],
+        format: null,
+        modifiers: ["requiresQuotes"]
       }
     ],
     "@typescript-eslint/no-unused-vars": [

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Build
         run: yarn build
 
+      - name: Lint
+        run: yarn lint
+
       - name: Get workspaces
         uses: sergeysova/jq-action@v2
         id: workspaces

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,5 +20,8 @@ jobs:
       - name: Yarn install
         run: yarn install
 
+      - name: Lint
+        run: yarn lint
+
       - name: Build
         run: yarn build

--- a/carina/package.json
+++ b/carina/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "build": "vue-cli-service build",
     "clean": "rimraf dist",
-    "lint": "vue-cli-service lint src",
+    "lint": "vue-cli-service lint src --no-fix",
     "serve": "vue-cli-service serve"
   }
 }

--- a/carina/src/Carina.vue
+++ b/carina/src/Carina.vue
@@ -489,7 +489,7 @@ export default defineComponent({
         const splashScreenListener = (_event: KeyboardEvent) => {
           this.showSplashScreen = false;
           window.removeEventListener('keyup', splashScreenListener);
-        }
+        };
         window.addEventListener('keyup', splashScreenListener);
 
         window.addEventListener('keyup', (event: KeyboardEvent) => {
@@ -514,7 +514,7 @@ export default defineComponent({
       const splashScreenListener = (_event: KeyboardEvent) => {
         this.showSplashScreen = false;
         window.removeEventListener('keypress', splashScreenListener);
-      }
+      };
       window.addEventListener('keypress', splashScreenListener);
 
     });

--- a/carina/src/Carina.vue
+++ b/carina/src/Carina.vue
@@ -476,11 +476,11 @@ export default defineComponent({
             mode: "autodetect",
             name: key,
             goto: false
-        }).then((layer) => {
-          this.layers[key] = layer;
-          applyImageSetLayerSetting(layer, ["opacity", 0.5]);
-        });
-      }));
+          }).then((layer) => {
+            this.layers[key] = layer;
+            applyImageSetLayerSetting(layer, ["opacity", 0.5]);
+          });
+        }));
 
       Promise.all(layerPromises).then(() => {
         this.resetView();

--- a/carina/src/Carina.vue
+++ b/carina/src/Carina.vue
@@ -453,7 +453,7 @@ export default defineComponent({
         { name: "facebook", color: "#1877f2", text: "Share" },
         { name: "twitter", color: "#1da1f2", text: "Tweet" },
       ]
-    }
+    };
   },
 
   created() {
@@ -610,11 +610,11 @@ export default defineComponent({
     },
 
     resetView(instant = true) {
-      const D2R = Math.PI / 180.0;
+      const d2R = Math.PI / 180.0;
       const imageset = this.layers.jwst.get_imageSet();
       this.gotoRADecZoom({
-        raRad: D2R * imageset.get_centerX(),
-        decRad: D2R * imageset.get_centerY(),
+        raRad: d2R * imageset.get_centerX(),
+        decRad: d2R * imageset.get_centerY(),
         zoomDeg: 0.8595,
         rollRad: 1.799,
         instant: instant,

--- a/carina/src/main.ts
+++ b/carina/src/main.ts
@@ -72,29 +72,29 @@ createApp(Carina, {
   bgName: "unwise"
 })
 
-// Plugins
-.use(wwtPinia)
-.use(vuetify)
+  // Plugins
+  .use(wwtPinia)
+  .use(vuetify)
 
-// Directives
-.directive(
-/**
-* Hides an HTML element, keeping the space it would have used if it were visible (css: Visibility)
-*/
-"hide", {
-  // Run on initialisation (first render) of the directive on the element
-  beforeMount(el, binding, _vnode, _prevVnode) {
-    update(el, binding);
-  },
-  // Run on subsequent updates to the value supplied to the directive
-  updated(el, binding, _vnode, _prevVnode) {
-    update(el, binding);
-  }
-})
+  // Directives
+  .directive(
+    /**
+    * Hides an HTML element, keeping the space it would have used if it were visible (css: Visibility)
+    */
+    "hide", {
+      // Run on initialisation (first render) of the directive on the element
+      beforeMount(el, binding, _vnode, _prevVnode) {
+        update(el, binding);
+      },
+      // Run on subsequent updates to the value supplied to the directive
+      updated(el, binding, _vnode, _prevVnode) {
+        update(el, binding);
+      }
+    })
 
-// Components
-.component("WorldWideTelescope", WWTComponent)
-.component('font-awesome-icon', FontAwesomeIcon)
+  // Components
+  .component("WorldWideTelescope", WWTComponent)
+  .component('font-awesome-icon', FontAwesomeIcon)
 
-// Mount
-.mount("#app");
+  // Mount
+  .mount("#app");

--- a/carina/src/main.ts
+++ b/carina/src/main.ts
@@ -2,7 +2,7 @@ import Vue, { createApp } from "vue";
 
 import Carina from "./Carina.vue";
 
-import vuetify from "../plugins/vuetify"
+import vuetify from "../plugins/vuetify";
 
 import { library } from '@fortawesome/fontawesome-svg-core';
 import {
@@ -29,7 +29,7 @@ import {
 import {
   faFacebook,
   faTwitter
-} from '@fortawesome/free-brands-svg-icons'
+} from '@fortawesome/free-brands-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 
 library.add(faAdjust);
@@ -84,11 +84,11 @@ createApp(Carina, {
 "hide", {
   // Run on initialisation (first render) of the directive on the element
   beforeMount(el, binding, _vnode, _prevVnode) {
-    update(el, binding)
+    update(el, binding);
   },
   // Run on subsequent updates to the value supplied to the directive
   updated(el, binding, _vnode, _prevVnode) {
-    update(el, binding)
+    update(el, binding);
   }
 })
 

--- a/common/package.json
+++ b/common/package.json
@@ -7,13 +7,16 @@
     "vue": "^3"
   },
   "devDependencies": {
+    "eslint": "^8.31.0",
+    "eslint-plugin-vue": "^9.8.0",
     "typescript": "^4.9.4",
     "webpack": "^5.75.0"
   },
   "main": "./dist/src/index.js",
   "scripts": {
     "build": "tsc",
-    "clean": "rimraf dist"
+    "clean": "rimraf dist",
+    "lint": "eslint --ext .ts,.vue src/"
   },
   "types": "./dist/src/index.d.ts"
 }

--- a/common/src/components/MiniDSBase.ts
+++ b/common/src/components/MiniDSBase.ts
@@ -21,7 +21,7 @@ export default defineComponent({
       resizeObserver: null as ResizeObserver | null,
       touchscreen: false,
       windowShape: defaultWindowShape,
-    }
+    };
   },
 
   created() {

--- a/green-comet/package.json
+++ b/green-comet/package.json
@@ -36,7 +36,7 @@
   "scripts": {
     "build": "vue-cli-service build",
     "clean": "rimraf dist",
-    "lint": "vue-cli-service lint src",
+    "lint": "vue-cli-service lint src --no-fix",
     "serve": "vue-cli-service serve"
   }
 }

--- a/green-comet/package.json
+++ b/green-comet/package.json
@@ -7,6 +7,7 @@
     "@vuepic/vue-datepicker": "^3.6.5",
     "@wwtelescope/astro": "^0.2.2",
     "d3-dsv": "^3.0.1",
+    "date-fns": "^2.29.3",
     "date-fns-tz": "^2.0.0",
     "leaflet": "^1.9.3",
     "tz-lookup": "^6.1.25",

--- a/green-comet/src/C2022E3.vue
+++ b/green-comet/src/C2022E3.vue
@@ -621,14 +621,14 @@ import { csvFormatRows, csvParse } from "d3-dsv";
 
 import { distance } from "@wwtelescope/astro";
 import { Color, Constellations, Folder, Grids, Layer, LayerManager, Poly, RenderContext, Settings, SpreadSheetLayer, WWTControl } from "@wwtelescope/engine";
-import { ImageSetType, MarkerScales, PlotTypes, PointScaleTypes, Thumbnail } from "@wwtelescope/engine-types";
+import { MarkerScales, PlotTypes, Thumbnail } from "@wwtelescope/engine-types";
 
 import L, { LeafletMouseEvent, Map } from "leaflet";
 import { getTimezoneOffset } from "date-fns-tz";
 import tzlookup from "tz-lookup";
-import { MiniDSBase, BackgroundImageset, skyBackgroundImagesets } from "@minids/common"
+import { MiniDSBase, BackgroundImageset, skyBackgroundImagesets } from "@minids/common";
 
-import { ImageSetLayer, Place, Imageset } from "@wwtelescope/engine";
+import { ImageSetLayer, Place } from "@wwtelescope/engine";
 import { applyImageSetLayerSetting } from "@wwtelescope/engine-helpers";
 
 import { drawSkyOverlays, initializeConstellationNames, makeAltAzGridText, drawSpreadSheetLayer, layerManagerDraw } from "./wwt-hacks";
@@ -653,46 +653,46 @@ const MILLISECONDS_PER_DAY = 1000 * SECONDS_PER_DAY;
 function parseCsvTable(csv: string) {
   return csvParse(csv, (d) => {
     return {
-      date: new Date(d.Date!),
-      ra: +d.RA!,
-      dec: +d.Dec!,
-      tMag: +d.Tmag!,
-      angspeed: +d.SkyMotion!,
+      date: new Date(d.Date ?? ""),
+      ra: +(d.RA ?? ""),
+      dec: +(d.Dec ?? ""),
+      tMag: +(d.Tmag ?? ""),
+      angspeed: +(d.SkyMotion ?? ""),
     };
   });
 }
-const FullDatesTable = parseCsvTable(ephemerisFullDatesCsv);
-const CometImageDatesTable = parseCsvTable(ephemerisCometImageDatesCsv);
+const fullDatesTable = parseCsvTable(ephemerisFullDatesCsv);
+const cometImageDatesTable = parseCsvTable(ephemerisCometImageDatesCsv);
 
 // NB: The two tables have identical structures.
 // We aren't exporting these types anywhere, so
 // generic names are fine
-type Table = typeof FullDatesTable;
-type TableRow = typeof FullDatesTable[number];
+type Table = typeof fullDatesTable;
+type TableRow = typeof fullDatesTable[number];
 
 function formatCsvTable(table: Table): string {
   return csvFormatRows([[
-        "Date", "RA", "Dec", "Tmag" , "Angspeed"
-      ]].concat(table.map((d, _i) => {
-        return [
-          d.date.toISOString(),
-          d.ra.toString(),
-          d.dec.toString(),
-          d.tMag.toString(),
-          d.angspeed.toString(),
-        ];
-    }))).replace(/\n/g, '\r\n');
-    // By using a regex, we replace all instances.
-    // For WWT implementation reasons (left over from 
-    // the Windows client?), we need the line endings 
-    // to be CRLF
+    "Date", "RA", "Dec", "Tmag" , "Angspeed"
+  ]].concat(table.map((d, _i) => {
+    return [
+      d.date.toISOString(),
+      d.ra.toString(),
+      d.dec.toString(),
+      d.tMag.toString(),
+      d.angspeed.toString(),
+    ];
+  }))).replace(/\n/g, '\r\n');
+  // By using a regex, we replace all instances.
+  // For WWT implementation reasons (left over from 
+  // the Windows client?), we need the line endings 
+  // to be CRLF
 }
 
-const FullDatesString = formatCsvTable(FullDatesTable);
-const CometImageDatesString = formatCsvTable(CometImageDatesTable);
+const fullDatesString = formatCsvTable(fullDatesTable);
+const cometImageDatesString = formatCsvTable(cometImageDatesTable);
 
-const allDates = FullDatesTable.map(r => r.date.getTime());
-const cometImageDates = CometImageDatesTable.map(r => r.date.getTime());
+const allDates = fullDatesTable.map(r => r.date.getTime());
+const cometImageDates = cometImageDatesTable.map(r => r.date.getTime());
 const minDate = Math.min(...allDates, ...cometImageDates);
 const maxDate = Math.max(...allDates, ...cometImageDates);
 const dates: number[] = [];
@@ -709,17 +709,17 @@ while (t <= maxDate) {
 type LocationRad = {
   longitudeRad: number;
   latitudeRad: number;
-}
+};
 
 type EquatorialRad = {
   raRad: number;
   decRad: number;
-}
+};
 
 type HorizontalRad = {
   altRad: number;
   azRad: number;
-}
+};
 
 type SheetType = "text" | "video" | null;
 
@@ -811,7 +811,7 @@ export default defineComponent({
         longitudeRad: D2R * -71.1281
       } as LocationRad,
       locationErrorMessage: ""
-    }
+    };
   },
 
   mounted() {
@@ -863,7 +863,7 @@ export default defineComponent({
       layerPromises.push(this.createTableLayer({
         name: "All Dates",
         referenceFrame: "Sky",
-        dataCsv: FullDatesString
+        dataCsv: fullDatesString
       }).then((layer) => {
         layer.set_lngColumn(1);
         layer.set_latColumn(2);
@@ -885,7 +885,7 @@ export default defineComponent({
       layerPromises.push(this.createTableLayer({
         name: "Comet Image Dates",
         referenceFrame: "Sky",
-        dataCsv: CometImageDatesString
+        dataCsv: cometImageDatesString
       }).then((layer) => {
         layer.set_lngColumn(1);
         layer.set_latColumn(2);
@@ -916,7 +916,7 @@ export default defineComponent({
         const splashScreenListener = (_event: KeyboardEvent) => {
           this.showSplashScreen = false;
           window.removeEventListener('keyup', splashScreenListener);
-        }
+        };
         window.addEventListener('keyup', splashScreenListener);
 
         window.addEventListener('keyup', (event: KeyboardEvent) => {
@@ -1070,10 +1070,10 @@ export default defineComponent({
       if (index === -1) { return null; }
       const row = table[index];
       const nextRow = table[index + 1] ?? row;
-      const delta_t = (nextRow.date.getTime() - row.date.getTime()) / MILLISECONDS_PER_DAY;
+      const deltaT = (nextRow.date.getTime() - row.date.getTime()) / MILLISECONDS_PER_DAY;
       // get how far we are into the day
       const dayFracPassed = (row.date.getTime() / MILLISECONDS_PER_DAY) % 1;
-      const f = (this.dayFrac - dayFracPassed) / delta_t;
+      const f = (this.dayFrac - dayFracPassed) / deltaT;
       const interpolatedRA = (1 - f) * row.ra + f * nextRow.ra;
       const interpolatedDec = (1 - f) * row.dec + f * nextRow.dec;
       
@@ -1100,7 +1100,7 @@ export default defineComponent({
 
     updateLayersForDate() {
 
-      this.interpolatedDailyTable = this.interpolatedTable(FullDatesTable);
+      this.interpolatedDailyTable = this.interpolatedTable(fullDatesTable);
       if (this.currentAllLayer !== null) {
         this.deleteLayer(this.currentAllLayer.id);
         this.currentAllLayer = null;
@@ -1190,7 +1190,6 @@ export default defineComponent({
 
     
     onItemSelected(place: Place) {
-      this.logTimes(`onItemSelected: ${place.get_name()}`)
       const iset = place.get_studyImageset() ?? place.get_backgroundImageset();
       if (iset == null) { return; }
       const layer = this.imagesetLayers[iset.get_name()];
@@ -1201,13 +1200,13 @@ export default defineComponent({
       });
       const [month, day, year] = iset.get_name().split("/").map(x => parseInt(x));
       this.selectedTime = Date.UTC(year, month - 1, day); 
-      this.showImageForDateTime(this.dateTime)
+      this.showImageForDateTime(this.dateTime);
       // this.updateViewForDate();
 
       // Give time for the selectedTime changes to propagate
       setTimeout(() => {
         this.$nextTick(() => {
-          if (this.image_out_of_view(place) || this.need_to_zoom_in(place)) {
+          if (this.imageOutOfView(place) || this.needToZoomIn(place)) {
             this.gotoRADecZoom({
               raRad: D2R * iset.get_centerX(),
               decRad: D2R * iset.get_centerY(),
@@ -1222,32 +1221,32 @@ export default defineComponent({
 
     wwtSmallestFov(): number {
       // ignore the possibility of rotation
-      const w = this.wwtRenderContext.width
-      const h = this.wwtRenderContext.height
-      const fov_h = this.wwtRenderContext.get_fovAngle() * D2R
-      const fov_w = fov_h * w / h
-      return Math.min(fov_w, fov_h)
+      const w = this.wwtRenderContext.width;
+      const h = this.wwtRenderContext.height;
+      const fovH = this.wwtRenderContext.get_fovAngle() * D2R;
+      const fovW = fovH * w / h;
+      return Math.min(fovW, fovH);
     },
 
     radecInFOV(ra: number, dec: number, center_ra: number, center_dec: number, fov: number, fov_view: number, fraction_of_place: number): boolean {
       let dist = distance(ra, dec, center_ra, center_dec);
-      dist += (fraction_of_place - 1/2) * fov 
-      return dist < fov_view / 2
+      dist += (fraction_of_place - 1/2) * fov;
+      return dist < fov_view / 2;
     },
 
     moveIfTableRowOfFOV(position: TableRow) {
       // get imageset of date
-        const move = this.radecInFOV(
-          D2R * position.ra * D2R,
-          D2R * position.dec * D2R,
-          this.wwtRARad,
-          this.wwtDecRad,
-          10 * D2R,
-          this.wwtRenderContext.get_fovAngle() * D2R,
-          1/2
-        )
+      const move = this.radecInFOV(
+        D2R * position.ra * D2R,
+        D2R * position.dec * D2R,
+        this.wwtRARad,
+        this.wwtDecRad,
+        10 * D2R,
+        this.wwtRenderContext.get_fovAngle() * D2R,
+        1/2
+      );
 
-      return move
+      return move;
       
     },
     
@@ -1263,20 +1262,19 @@ export default defineComponent({
 
       const isetRa = iset.get_centerX() * D2R;
       const isetDec = iset.get_centerY() * D2R;
-      const isetFov = (place.get_zoomLevel() / 6) * D2R
+      const isetFov = (place.get_zoomLevel() / 6) * D2R;
       
       const curRa = this.wwtRARad;
       const curDec = this.wwtDecRad;
       const curFov = this.wwtSmallestFov();
 
-      const return_val = this.radecInFOV(isetRa, isetDec, curRa, curDec, isetFov, curFov, fraction_of_place) 
-      return return_val
+      return this.radecInFOV(isetRa, isetDec, curRa, curDec, isetFov, curFov, fraction_of_place);
     },
 
     // convenience wrapper for (not checkIfPlaceIsInTheCurrentFOV)
-    image_out_of_view(place: Place): boolean { return !this.checkIfPlaceIsInTheCurrentFOV(place) },
+    imageOutOfView(place: Place): boolean { return !this.checkIfPlaceIsInTheCurrentFOV(place); },
 
-    need_to_zoom_in(place: Place, factor = 5): boolean {
+    needToZoomIn(place: Place, factor = 5): boolean {
       // 1) we are already zoomed all the way out (if FOV > 50)
       if (this.wwtZoomDeg > 300) { return true; }
 
@@ -1286,7 +1284,7 @@ export default defineComponent({
         if (place.get_zoomLevel() * factor < this.wwtZoomDeg) { return true; }
       }
       
-      return false
+      return false;
     },
 
     onTimeSliderchange(options?: MoveOptions) {
@@ -1305,8 +1303,8 @@ export default defineComponent({
       
 
       this.$nextTick(() => {
-        const zoom = this.need_to_zoom_in(place, 2.5) ? place.get_zoomLevel() * 2.5 : this.wwtZoomDeg;
-        if ((this.image_out_of_view(place) && move) || (this.need_to_zoom_in(place, 8) && move) ) {
+        const zoom = this.needToZoomIn(place, 2.5) ? place.get_zoomLevel() * 2.5 : this.wwtZoomDeg;
+        if ((this.imageOutOfView(place) && move) || (this.needToZoomIn(place, 8) && move) ) {
           const [month, day, year] = iset.get_name().split("/").map(x => parseInt(x));
           this.selectedTime = Date.UTC(year, month - 1, day); 
           this.incomingItemSelect = place;
@@ -1335,7 +1333,7 @@ export default defineComponent({
       // when we toggle the image we want to set it's opacity to zero
       const iset = place.get_studyImageset() ?? place.get_backgroundImageset();
       if (iset == null) { return; } 
-      const iname = iset.get_name()
+      const iname = iset.get_name();
       this.setLayerOpacityForImageSet(iname, checked ? 1 : 0);
     },
     
@@ -1372,7 +1370,7 @@ export default defineComponent({
       };
     },
 
-    circleForLocation(latDeg: number, lonDeg: number): L.Circle<any> {
+    circleForLocation(latDeg: number, lonDeg: number): L.Circle {
       return L.circle([latDeg, lonDeg], {
         color: "#FF0000",
         fillColor: "#FF0033",
@@ -1389,7 +1387,7 @@ export default defineComponent({
           this.location = {
             longitudeRad: D2R * position.coords.longitude,
             latitudeRad: D2R * position.coords.latitude
-          }
+          };
 
           if (this.map) {
             this.map.setView([position.coords.latitude, position.coords.longitude], this.map.getZoom());
@@ -1430,7 +1428,7 @@ export default defineComponent({
       return { ra, dec };
     },
 
-    get_julian(utc: Date): number {
+    getJulian(utc: Date): number {
       let year = utc.getUTCFullYear();
       let month = utc.getUTCMonth()+1;
       const day = utc.getUTCDate();
@@ -1440,8 +1438,8 @@ export default defineComponent({
 
       if (month == 1 || month == 2)
       {
-          year -= 1;
-          month += 12;
+        year -= 1;
+        month += 12;
       }
 
       const a = Math.floor(year / 100);
@@ -1450,19 +1448,19 @@ export default defineComponent({
       const d = Math.floor(30.6001 * (month + 1));
 
       // gives julian date: number of days since Jan 1, 4713 BC
-      const JD = b + c + d + 1720994.5 + day + (hour + minute / 60.00 + second / 3600.00) / 24.00;
-      return JD
+      const jd = b + c + d + 1720994.5 + day + (hour + minute / 60.00 + second / 3600.00) / 24.00;
+      return jd;
 
     },
     
     mstFromUTC2(utc: Date, longRad: number): number {
       const lng = longRad * R2D;
 
-      const modified_jd = this.get_julian(utc)  - 2451545;
+      const modifiedJD = this.getJulian(utc)  - 2451545;
 
-      const julianCenturies = modified_jd / 36525.0;
+      const julianCenturies = modifiedJD / 36525.0;
       // this form wants julianDays - 2451545
-      let mst = 280.46061837 + 360.98564736629 * modified_jd + 0.000387933 * julianCenturies * julianCenturies - julianCenturies * julianCenturies * julianCenturies / 38710000 + lng;
+      let mst = 280.46061837 + 360.98564736629 * modifiedJD + 0.000387933 * julianCenturies * julianCenturies - julianCenturies * julianCenturies * julianCenturies / 38710000 + lng;
 
       if (mst > 0.0) {
         while (mst > 360.0) {
@@ -1529,9 +1527,9 @@ export default defineComponent({
 
       // The initial coordinates are given in Alt/Az, then converted to RA/Dec
       // Use N annotations to cover below the horizon
-      const N = 6;
-      const delta = 2 * Math.PI / N;
-      for (let i = 0; i < N; i++) {
+      const n = 6;
+      const delta = 2 * Math.PI / n;
+      for (let i = 0; i < n; i++) {
         let points: [number, number][] = [
           [0, i * delta],
           [-Math.PI / 2, i * delta],
@@ -1561,7 +1559,7 @@ export default defineComponent({
       let minDist = Infinity;
       let closestPt = null as TableRow | null;
 
-      [CometImageDatesTable, FullDatesTable].forEach((table) => {
+      [cometImageDatesTable, fullDatesTable].forEach((table) => {
         table.forEach(row => {
           const raRad = row.ra * D2R;
           const decRad = row.dec * D2R;
@@ -1637,21 +1635,20 @@ export default defineComponent({
     },
 
     updateViewForDate(options?: MoveOptions) {
-      this.logTimes("updateViewForDate", new Date(this.selectedTime));
       let position = null as TableRow | null;
 
       const cometImageIndex = cometImageDates.findIndex(d => d === this.selectedTime);
       
       if (cometImageIndex > -1) {
         if (this.interpolatedDailyTable !== null) {
-          position = this.interpolatedDailyTable[0]
+          position = this.interpolatedDailyTable[0];
         } else {
-          position = CometImageDatesTable[cometImageIndex];
+          position = cometImageDatesTable[cometImageIndex];
         }
       } else {
         const allIndex = allDates.findIndex(d => d === this.selectedTime);
         if (allIndex > -1) {
-          position = FullDatesTable[allIndex];
+          position = fullDatesTable[allIndex];
         }
       }
 
@@ -1676,15 +1673,15 @@ export default defineComponent({
 
     matchImageSetName(date: Date): string {
       // imageset names are keys in this.imagesetLayers
-      const imageset_names = Object.keys(this.imagesetLayers)
+      const imagesetNames = Object.keys(this.imagesetLayers);
       // loop over image set names. find the name (which is a MM/DD/YYYY date string) 
       // that is or comes after the date we are looking for
       
-      for (const name of imageset_names) {
+      for (const name of imagesetNames) {
         // convert the name to a date
         // if the name is after the date we are looking for, return it
-        const wwt_date_string = this.namefromDate(date)
-        if (name == wwt_date_string) {
+        const wwtDateString = this.namefromDate(date);
+        if (name == wwtDateString) {
           return name;
         }
       }
@@ -1692,31 +1689,31 @@ export default defineComponent({
     },
 
     setLayerOpacityForImageSet(name: string, opacity: number, setting_opacity_from_ui=false) {
-      const layer = this.imagesetLayers[name]
+      const layer = this.imagesetLayers[name];
       if (layer != null) {
         // update the image opacity in the WWT control
-        applyImageSetLayerSetting(layer, ['opacity', opacity])
+        applyImageSetLayerSetting(layer, ['opacity', opacity]);
 
         // update the value for the slider only if we are not setting the opacity from the UI
         if (!setting_opacity_from_ui) {
-          const selector = `#items div.item[title='${name}'] input.opacity-range[type='range']`
-          const el = (document.querySelector(selector) as HTMLInputElement)
+          const selector = `#items div.item[title='${name}'] input.opacity-range[type='range']`;
+          const el = (document.querySelector(selector) as HTMLInputElement);
           if (el != null) {
-            el.value = `${opacity * 100}`
+            el.value = `${opacity * 100}`;
           }
         }
 
-        const toggle_selector = `#items input[type='checkbox'][title='${name}']`
-        const el2 = (document.querySelector(toggle_selector) as HTMLInputElement)
+        const toggleSelector = `#items input[type='checkbox'][title='${name}']`;
+        const el2 = (document.querySelector(toggleSelector) as HTMLInputElement);
         // truth table: opacity == 0 and el.checked == false => do nothing
         // truth table: opacity == 0 and el.checked == true => set el.checked = false
         // truth table: opacity > 0 and el.checked == false => set el.checked = true
         // truth table: opacity > 0 and el.checked == true => do nothing
         if (el2 != null) {
           if (opacity == 0 && el2.checked) {
-            el2.checked = false
+            el2.checked = false;
           } else if (opacity > 0 && !el2.checked) {
-            el2.checked = true
+            el2.checked = true;
           }
         }
         
@@ -1724,23 +1721,23 @@ export default defineComponent({
     },
     
     showImageForDateTime(date: Date) {
-      const name = this.matchImageSetName(date)
+      const name = this.matchImageSetName(date);
       if (name == null) {
-        this.incomingItemSelect = null
+        this.incomingItemSelect = null;
         return;
       }
-      const imageset_names = Object.keys(this.imagesetLayers)
-      imageset_names.forEach((iname: string) => {
+      const imagesetNames = Object.keys(this.imagesetLayers);
+      imagesetNames.forEach((iname: string) => {
         if (iname != name) {
-          this.setLayerOpacityForImageSet(iname, 0)
+          this.setLayerOpacityForImageSet(iname, 0);
         } else {
-          this.setLayerOpacityForImageSet(iname, 1)
+          this.setLayerOpacityForImageSet(iname, 1);
           // need to get the Place object for the image set and use it to set the view
           if (this.imagesetFolder != null) {
-            const places = this.imagesetFolder.get_children()
+            const places = this.imagesetFolder.get_children();
             if (places != null) {
-              const place = places.filter((place) => place.get_name() == iname)
-              this.incomingItemSelect = place[0]
+              const place = places.filter((place) => place.get_name() == iname);
+              this.incomingItemSelect = place[0];
             }
           }
           // const iset = this.wwtControl.getImagesetByName(iname)
@@ -1752,7 +1749,7 @@ export default defineComponent({
           //   instant: true
           // });
         }
-      })
+      });
       
     },
 
@@ -1768,8 +1765,7 @@ export default defineComponent({
     },
 
     updateForDateTime() {
-      this.logTimes('updateForDateTime')
-      if (!this.dontSetTime) { this.setTime(this.dateTime) }
+      if (!this.dontSetTime) { this.setTime(this.dateTime); }
       this.updateHorizon(this.dateTime); 
       // this.showImageForDateTime(this.dateTime);
       // this.updateViewForDate(options);
@@ -1777,7 +1773,6 @@ export default defineComponent({
     },
 
     updateHorizon(when: Date | null = null) {
-      this.logTimes('updateHorizon',when)
       if (this.showHorizon) {
         this.createHorizon(when);
       } else {
@@ -1791,17 +1786,6 @@ export default defineComponent({
       if (children == null) { return; }
       const place = children[0] as Place;
       this.onItemSelected(place);
-    },
-
-    logTimes(pre: string, date = null as Date | null) { 
-      // console.log('running',pre)
-      // console.log("::: selectedTime:", new Date(this.selectedTime))
-      // console.log('::: selectedDate:', this.selectedDate)
-      // console.log('::: wwtCurrentTime:', this.wwtCurrentTime)
-      // date = null // disable block w/o deleting (i.e. stop typescript from complaining)
-      // if (date != null) {
-      //   console.log('::: manual date:', date)
-      // }
     }
   },
 
@@ -1841,12 +1825,7 @@ export default defineComponent({
     },
 
     selectedDate() {
-      this.logTimes('selectedDate')
       this.updateForDateTime();
-    },
-
-    selectedTime() {
-      this.logTimes('selectedTime')
     },
     
     showLocationSelector(show: boolean) {
@@ -1886,7 +1865,7 @@ export default defineComponent({
           this.$nextTick(() => {
             this.showImageForDateTime(this.dateTime);
             this.updateViewForDate();
-          })
+          });
         }, 350);
       }
     },

--- a/green-comet/src/FolderView.vue
+++ b/green-comet/src/FolderView.vue
@@ -140,7 +140,7 @@ export default defineComponent({
       opacities: {} as Record<string, number>,
       expanded: this.open,
       lastOpacityChanged: null as Thumbnail | null
-    }
+    };
   },
 
   created() {
@@ -171,9 +171,9 @@ export default defineComponent({
       }
     },
     onSliderInputChanged(e: Event, item: Thumbnail) {
-      let dragging = false
+      let dragging = false;
       if (this.lastOpacityChanged == item) {
-        dragging = true
+        dragging = true;
       } else {
         this.lastOpacityChanged = item;
       }
@@ -189,7 +189,6 @@ export default defineComponent({
       if (element !== null) {
         const container = document.getElementById("items");
         if (container !== null) {
-          console.log(element.clientHeight);
           const y = Math.max(Math.min(element.offsetTop - element.clientHeight * 1.5, container.scrollHeight), 0);
           container.scrollTo(0, y);
         }
@@ -201,7 +200,7 @@ export default defineComponent({
     cssVars() {
       return {
         "--flex-direction": this.flexDirection
-      }
+      };
     },
 
     isMobile() {
@@ -215,7 +214,7 @@ export default defineComponent({
         this.lastSelectedItem = this.incomingItemSelect;
         this.scrollToItem(`fv-${this.incomingItemSelect.get_name()}`);
       } else {
-        this.lastSelectedItem = null
+        this.lastSelectedItem = null;
       }
     }
   }

--- a/green-comet/src/TransitionExpand.vue
+++ b/green-comet/src/TransitionExpand.vue
@@ -70,7 +70,7 @@ export default defineComponent({
       requestAnimationFrame(() => {
         element.style.height = "0";
       });
-      this.$emit('leave')
+      this.$emit('leave');
     }
   }
 });

--- a/green-comet/src/main.ts
+++ b/green-comet/src/main.ts
@@ -7,12 +7,12 @@ import TransitionExpand from "./TransitionExpand.vue";
 import "./polyfills";
 
 import VueSlider from "vue-slider-component";
-import 'vue-slider-component/theme/default.css'
+import 'vue-slider-component/theme/default.css';
 
 import Datepicker from '@vuepic/vue-datepicker';
-import '@vuepic/vue-datepicker/dist/main.css'
+import '@vuepic/vue-datepicker/dist/main.css';
 
-import vuetify from "../plugins/vuetify"
+import vuetify from "../plugins/vuetify";
 
 import { library } from '@fortawesome/fontawesome-svg-core';
 import {
@@ -69,35 +69,35 @@ createApp(C2022E3, {
   bgName: "unwise"
 })
 
-// Plugins
-.use(wwtPinia)
-.use(vuetify)
-.use(Notifications)
+  // Plugins
+  .use(wwtPinia)
+  .use(vuetify)
+  .use(Notifications)
 
-// Directives
-.directive(
-/**
-* Hides an HTML element, keeping the space it would have used if it were visible (css: Visibility)
-*/
-"hide", {
-  // Run on initialisation (first render) of the directive on the element
-  beforeMount(el, binding, _vnode, _prevVnode) {
-    update(el, binding)
-  },
-  // Run on subsequent updates to the value supplied to the directive
-  updated(el, binding, _vnode, _prevVnode) {
-    update(el, binding)
-  }
-})
+  // Directives
+  .directive(
+    /**
+    * Hides an HTML element, keeping the space it would have used if it were visible (css: Visibility)
+    */
+    "hide", {
+      // Run on initialisation (first render) of the directive on the element
+      beforeMount(el, binding, _vnode, _prevVnode) {
+        update(el, binding);
+      },
+      // Run on subsequent updates to the value supplied to the directive
+      updated(el, binding, _vnode, _prevVnode) {
+        update(el, binding);
+      }
+    })
 
-// Components
-.component("WorldWideTelescope", WWTComponent)
-.component('font-awesome-icon', FontAwesomeIcon)
-.component('font-awesome-layers', FontAwesomeLayers)
-.component('folder-view', FolderView)
-.component('vue-slider', VueSlider)
-.component('transition-expand', TransitionExpand)
-.component('date-picker', Datepicker)
+  // Components
+  .component("WorldWideTelescope", WWTComponent)
+  .component('font-awesome-icon', FontAwesomeIcon)
+  .component('font-awesome-layers', FontAwesomeLayers)
+  .component('folder-view', FolderView)
+  .component('vue-slider', VueSlider)
+  .component('transition-expand', TransitionExpand)
+  .component('date-picker', Datepicker)
 
-// Mount
-.mount("#app");
+  // Mount
+  .mount("#app");

--- a/green-comet/src/polyfills.ts
+++ b/green-comet/src/polyfills.ts
@@ -1,20 +1,21 @@
 // Polyfill for Array.at
-const TypedArray = Reflect.getPrototypeOf(Int8Array);
-for (const C of [Array, String, TypedArray]) {
+const typedArray = Reflect.getPrototypeOf(Int8Array);
+for (const c of [Array, String, typedArray]) {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
-  Object.defineProperty(C.prototype, "at",
-                        { value: function at(n: any) {
-                            // ToInteger() abstract op
-                            n = Math.trunc(n) || 0;
-                            // Allow negative indexing from the end
-                            if (n < 0) n += this.length;
-                            // OOB access is guaranteed to return undefined
-                            if (n < 0 || n >= this.length) return undefined;
-                            // Otherwise, this is just normal property access
-                            return this[n];
-                          },
-                          writable: true,
-                          enumerable: false,
-                          configurable: true });
+  Object.defineProperty(c.prototype, "at",
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    { value: function at(n: any) {
+      // ToInteger() abstract op
+      n = Math.trunc(n) || 0;
+      // Allow negative indexing from the end
+      if (n < 0) n += this.length;
+      // OOB access is guaranteed to return undefined
+      if (n < 0 || n >= this.length) return undefined;
+      // Otherwise, this is just normal property access
+      return this[n];
+    },
+    writable: true,
+    enumerable: false,
+    configurable: true });
 }

--- a/green-comet/src/wwt-hacks.ts
+++ b/green-comet/src/wwt-hacks.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 
- /* eslint-disable */
+/* eslint-disable */
 
 import {
   Color, Colors, Constellations, Coordinates, Grids,

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     ],
     "scripts": {
         "build": "yarn workspaces foreach -vt run build",
-        "clean": "yarn workspaces foreach -vt run clean"
+        "clean": "yarn workspaces foreach -vt run clean",
+        "lint": "yarn workspaces foreach -vt run lint"
     },
     "dependencies": {
         "@mdi/font": "^7.1.96",

--- a/yarn.lock
+++ b/yarn.lock
@@ -479,6 +479,8 @@ __metadata:
   resolution: "@minids/common@workspace:common"
   dependencies:
     "@wwtelescope/engine-pinia": ^0.2.0
+    eslint: ^8.31.0
+    eslint-plugin-vue: ^9.8.0
     screenfull: ^6.0.2
     typescript: ^4.9.4
     vue: ^3
@@ -505,6 +507,7 @@ __metadata:
     "@vuepic/vue-datepicker": ^3.6.5
     "@wwtelescope/astro": ^0.2.2
     d3-dsv: ^3.0.1
+    date-fns: ^2.29.3
     date-fns-tz: ^2.0.0
     eslint: ^8.31.0
     eslint-plugin-vue: ^9.8.0


### PR DESCRIPTION
This PR uses ESLint to add a linting check to both the PR and deployment CI workflows. I probably should've included this to begin with, but as this project gets larger I think it will make things easier if we keep our code consistent across the various data stories.

I've gone with a pretty standard set of JavaScript/TypeScript rules:

* Unused variables and parameters should start with an underscore (i.e. `_unused`)
* `camelCase` for functions, variables, members, parameters, etc.
     - Top-level global constants can be `UPPER_CASE`
     - No format for properties in quotes (so you can do `item["--someWeird_field"]`)
* `PascalCase` for classes/types/interfaces
* Semicolons to end statements

The `camelCase` style and leading underscore for unused variables is also the same as what WWT uses, which is good since we're obviously importing a lot from there (also, all of the WWT types use `PascalCase`, even though I don't see it being enforced by the linter there).

Along with the CI updates, this PR currently contains some minor linting updates to Carina. Once the dust has settled on the comet story I can rebase this onto main and make any necessary updates there as well.