### PR TITLE
Minor comet story tweaks

### DIFF
--- a/green-comet/src/C2022E3.vue
+++ b/green-comet/src/C2022E3.vue
@@ -1204,6 +1204,9 @@ export default defineComponent({
       this.showImageForDateTime(this.dateTime);
       // this.updateViewForDate();
 
+      this.playing = false;
+      this.playingCometPath = false;
+
       // Give time for the selectedTime changes to propagate
       setTimeout(() => {
         this.$nextTick(() => {

--- a/green-comet/src/C2022E3.vue
+++ b/green-comet/src/C2022E3.vue
@@ -1901,7 +1901,7 @@ export default defineComponent({
             const image = this.showImageForDateTime(this.dateTime);
             this.updateViewForDate();
             if (image) {
-              this.playingWaitCount = 3;
+              this.playingWaitCount = 1;
             }
           });
         } else {

--- a/green-comet/src/FolderView.vue
+++ b/green-comet/src/FolderView.vue
@@ -35,7 +35,6 @@
             :class="['bordered', 'item', lastSelectedItem === item ? 'selected' : '']"
             v-for="item of items"
             :key="item.get_name()"
-            :title="item.get_name()"
             :id="`fv-${item.get_name()}`"
           >
             <div


### PR DESCRIPTION
This PR makes a few minor tweaks to the green comet story:

* Remove the hover text from the folder view thumbnail images
* Have the "Play Comet Images" functionality pause when going over a date that has an image. This is done using a counter that decrements during each `setInterval` call. If the counter is positive, the date is not moved forward.
* If a user clicks a thumbnail while the view is "playing" (either regular or comet images), the playing is stopped.