### PR TITLE
Re-add Safari testing to CI

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -47,7 +47,7 @@ jobs:
           yarn serve &
           sleep 10 # give the local service time to start up
           cd ../tests
-          yarn bs-local -e default,firefox,edge --group carina -o reports
+          yarn bs-local -e default,firefox,edge,safari --group carina -o reports
           pkill -f vue-cli-service # stop the servers
 
       - name: 'BrowserStackLocal Stop'  # Terminating the BrowserStackLocal tunnel connection

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
           yarn serve &
           sleep 10 # give the local service time to start up
           cd ../tests
-          yarn bs-local -e default,firefox,edge --group carina -o reports
+          yarn bs-local -e default,firefox,edge,safari --group carina -o reports
           pkill -f vue-cli-service # stop the servers
 
       - name: 'BrowserStackLocal Stop'  # Terminating the BrowserStackLocal tunnel connection

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     },
     "packageManager": "yarn@3.3.0",
     "devDependencies": {
+        "@types/chai": "^4.3.4",
         "rimraf": "^4.1.0"
     }
 }

--- a/tests/bslocal.conf.ts
+++ b/tests/bslocal.conf.ts
@@ -76,7 +76,7 @@ const simpleKeyMaker = function(_version: string, browser: string): string {
   return browser.toLowerCase();
 };
 addBrowsers(environments, BSLOCAL_CAPABILITIES, 'Windows', ['10'], ['Chrome', 'Firefox', 'MicrosoftEdge'], simpleKeyMaker);
-addBrowsers(environments, BSLOCAL_CAPABILITIES, 'OS X', ['Big Sur'], ['Safari'], simpleKeyMaker);
+addBrowsers(environments, BSLOCAL_CAPABILITIES, 'OS X', ['Ventura'], ['Safari'], simpleKeyMaker);
 
 // Code to copy seleniumhost/port into test settings
 for (const i in nightwatchConfig.test_settings) {
@@ -87,5 +87,4 @@ for (const i in nightwatchConfig.test_settings) {
   config['selenium_host'] = nightwatchConfig.selenium.host;
   config['selenium_port'] = nightwatchConfig.selenium.port;
 }
-
 module.exports = nightwatchConfig;

--- a/tests/carina/basic.ts
+++ b/tests/carina/basic.ts
@@ -6,6 +6,8 @@ import {
   WindowSize
 } from "nightwatch";
 
+import { assert } from "chai";
+
 import {
   expectAllNotPresent,
   expectAllVisible,
@@ -128,7 +130,7 @@ const tests: CarinaTests = {
       this.app.getElementSize("@mainContent", (mainContentSize) => {
         const wsize = windowSize.value as WindowSize;
         const csize = mainContentSize.value as WindowSize;
-        browser.assert.equal(Math.round(csize.height), Math.round(0.66 * wsize.height));
+        assert(Math.round(csize.height - 0.66 * wsize.height) < 2);
         browser.assert.equal(wsize.width, csize.width);
       });
     });

--- a/tests/config.ts
+++ b/tests/config.ts
@@ -24,15 +24,15 @@ export interface Capabilities {
 }
 
 export interface BrowserCapabilities extends Capabilities {
-  browser_version: string,
+  browserVersion: string,
   os: string,
-  os_version: string;
+  osVersion: string;
 }
 
 export interface MobileCapabilities extends Capabilities {
   device: string,
   real_mobile: boolean,
-  os_version: string;
+  osVersion: string;
 }
 
 export interface TestEnvironment {
@@ -56,16 +56,16 @@ export interface Configuration {
 export function browserCapabilities(browserName: string, browserVersion: string, osName: string, osVersion: string): BrowserCapabilities {
   return {
     'browserName': browserName,
-    'browser_version': browserVersion,
+    'browserVersion': browserVersion,
     'os': osName,
-    'os_version': osVersion,
+    'osVersion': osVersion,
   };
 }
 
 export function mobileCapabilities(deviceOS: string, deviceName: string, osVersion: string, realMobile=true): MobileCapabilities {
   return {
     'device': deviceName,
-    'os_version': osVersion,
+    'osVersion': osVersion,
     'real_mobile': realMobile,
     'browserName': deviceOS, // Seems strange, but this is what BrowserStack shows in their examples
   };

--- a/tests/package.json
+++ b/tests/package.json
@@ -5,6 +5,7 @@
     },
     "devDependencies": {
         "@types/nightwatch": "^2.3.18",
+        "chai": "^4.3.7",
         "chromedriver": "^110.0.0",
         "edgedriver": "^4.17134.1",
         "geckodriver": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -743,7 +743,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/chai@npm:*":
+"@types/chai@npm:*, @types/chai@npm:^4.3.4":
   version: 4.3.4
   resolution: "@types/chai@npm:4.3.4"
   checksum: 571184967beb03bf64c4392a13a7d44e72da9af5a1e83077ff81c39cf59c0fda2a5c78d2005084601cf8f3d11726608574d8b5b4a0e3e9736792807afd926cd0
@@ -6509,6 +6509,7 @@ __metadata:
     "@minids/carina": "workspace:*"
     "@minids/common": "workspace:*"
     "@minids/tests": "workspace:*"
+    "@types/chai": ^4.3.4
     rimraf: ^4.1.0
   languageName: unknown
   linkType: soft

--- a/yarn.lock
+++ b/yarn.lock
@@ -537,6 +537,7 @@ __metadata:
   dependencies:
     "@types/nightwatch": ^2.3.18
     browserstack-local: ^1.5.1
+    chai: ^4.3.7
     chromedriver: ^110.0.0
     edgedriver: ^4.17134.1
     geckodriver: ^3.2.0
@@ -2113,7 +2114,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"assertion-error@npm:1.1.0":
+"assertion-error@npm:1.1.0, assertion-error@npm:^1.1.0":
   version: 1.1.0
   resolution: "assertion-error@npm:1.1.0"
   checksum: fd9429d3a3d4fd61782eb3962ae76b6d08aa7383123fca0596020013b3ebd6647891a85b05ce821c47d1471ed1271f00b0545cf6a4326cf2fc91efcc3b0fbecf
@@ -2570,6 +2571,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chai@npm:^4.3.7":
+  version: 4.3.7
+  resolution: "chai@npm:4.3.7"
+  dependencies:
+    assertion-error: ^1.1.0
+    check-error: ^1.0.2
+    deep-eql: ^4.1.2
+    get-func-name: ^2.0.0
+    loupe: ^2.3.1
+    pathval: ^1.1.1
+    type-detect: ^4.0.5
+  checksum: 0bba7d267848015246a66995f044ce3f0ebc35e530da3cbdf171db744e14cbe301ab913a8d07caf7952b430257ccbb1a4a983c570a7c5748dc537897e5131f7c
+  languageName: node
+  linkType: hard
+
 "chalk@npm:^2.0.0, chalk@npm:^2.1.0":
   version: 2.4.2
   resolution: "chalk@npm:2.4.2"
@@ -2601,7 +2617,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"check-error@npm:1.0.2":
+"check-error@npm:1.0.2, check-error@npm:^1.0.2":
   version: 1.0.2
   resolution: "check-error@npm:1.0.2"
   checksum: d9d106504404b8addd1ee3f63f8c0eaa7cd962a1a28eb9c519b1c4a1dc7098be38007fc0060f045ee00f075fbb7a2a4f42abcf61d68323677e11ab98dc16042e
@@ -3447,6 +3463,15 @@ __metadata:
   dependencies:
     type-detect: ^4.0.0
   checksum: 304161c2d94566f36dcd6dea7b0cdbd555fe5e98eaab5f0d8203b12507f81ed4042e4040b3e4bd1c8f893f865cec643f725c6aa184984947fb69d1a80d19a9f7
+  languageName: node
+  linkType: hard
+
+"deep-eql@npm:^4.1.2":
+  version: 4.1.3
+  resolution: "deep-eql@npm:4.1.3"
+  dependencies:
+    type-detect: ^4.0.0
+  checksum: 7f6d30cb41c713973dc07eaadded848b2ab0b835e518a88b91bea72f34e08c4c71d167a722a6f302d3a6108f05afd8e6d7650689a84d5d29ec7fe6220420397f
   languageName: node
   linkType: hard
 
@@ -6216,6 +6241,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"loupe@npm:^2.3.1":
+  version: 2.3.6
+  resolution: "loupe@npm:2.3.6"
+  dependencies:
+    get-func-name: ^2.0.0
+  checksum: cc83f1b124a1df7384601d72d8d1f5fe95fd7a8185469fec48bb2e4027e45243949e7a013e8d91051a138451ff0552310c32aa9786e60b6a30d1e801bdc2163f
+  languageName: node
+  linkType: hard
+
 "lower-case@npm:^2.0.2":
   version: 2.0.2
   resolution: "lower-case@npm:2.0.2"
@@ -7437,7 +7471,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pathval@npm:1.1.1":
+"pathval@npm:1.1.1, pathval@npm:^1.1.1":
   version: 1.1.1
   resolution: "pathval@npm:1.1.1"
   checksum: 090e3147716647fb7fb5b4b8c8e5b55e5d0a6086d085b6cd23f3d3c01fcf0ff56fd3cc22f2f4a033bd2e46ed55d61ed8379e123b42afe7d531a2a5fc8bb556d6
@@ -9482,7 +9516,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-detect@npm:4.0.8, type-detect@npm:^4.0.0":
+"type-detect@npm:4.0.8, type-detect@npm:^4.0.0, type-detect@npm:^4.0.5":
   version: 4.0.8
   resolution: "type-detect@npm:4.0.8"
   checksum: 62b5628bff67c0eb0b66afa371bd73e230399a8d2ad30d852716efcc4656a7516904570cd8631a49a3ce57c10225adf5d0cbdcb47f6b0255fe6557c453925a15


### PR DESCRIPTION
This PR fixes the issues with Safari testing on BrowserStack and re-adds it to the CI. Turns out the issue was an update to the formatting of the expected fields in BrowserStack's config (`snake_case` -> `camelCase`), which was causing our Safari runs to happen on very old versions of macOS. There's also a small tweak to the test to add a little bit of tolerance (1 pixel) to the WWT component height when it shrinks.