### PR TITLE
Use regexes for Safari whitespace

### DIFF
--- a/tests/green-comet/basic.ts
+++ b/tests/green-comet/basic.ts
@@ -11,7 +11,6 @@ import { assert } from "chai";
 import {
   expectAllNotPresent,
   expectAllVisible,
-  hasClass
 } from "../utils";
 
 type GreenCometTests = NightwatchTests & { app: GreenCometPage; sections: GreenCometSections };

--- a/tests/green-comet/basic.ts
+++ b/tests/green-comet/basic.ts
@@ -11,6 +11,7 @@ import { assert } from "chai";
 import {
   expectAllNotPresent,
   expectAllVisible,
+  hasClass
 } from "../utils";
 
 type GreenCometTests = NightwatchTests & { app: GreenCometPage; sections: GreenCometSections };
@@ -65,17 +66,17 @@ const tests: GreenCometTests = {
     const folderView = this.sections.folderView;
     folderView.expect.elements("@folderItem").count.to.equal(folderView.props.folderImageCount);
     folderView.expect.element("@expandHeader").text.to.match(folderView.props.expandedHeaderText);
-    folderView.expect.element("@expandChevron").to.have.property("classList").contain("fa-chevron-up");
+    folderView.expect.element("@expandChevron").to.have.attribute("data-icon", "chevron-up");
 
     const controls = this.sections.controls;
-    controls.expect.element("@openCloseButton").to.have.property("classList").contain("fa-chevron-down");
+    controls.expect.element("@openCloseButton").to.have.attribute("data-icon", "chevron-down");
     controls.expect.element("@gridInput").to.be.selected;
     controls.expect.element("@constellationsInput").to.not.be.selected;
     controls.expect.element("@horizonInput").to.not.be.selected; 
 
-    controls.expect.element("@selectedLocationTimeLabel").text.to.equal(controls.props.selectedLocationTimeText);
-    controls.expect.element("@centerOnNowButtonContent").text.to.equal(controls.props.centerOnNowText);
-    controls.expect.element("@playCometImagesContent").text.to.equal(controls.props.playCometImagesText);
+    controls.expect.element("@selectedLocationTimeLabel").text.to.match(controls.props.selectedLocationTimeText);
+    controls.expect.element("@centerOnNowButtonContent").text.to.match(controls.props.centerOnNowText);
+    controls.expect.element("@playCometImagesContent").text.to.match(controls.props.playCometImagesText);
 
     expectAllVisible(controls, [
       "@topRow", "@openCloseButton",
@@ -142,8 +143,8 @@ const tests: GreenCometTests = {
       "@useMyLocationButton",
       "@mapContainer"
     ]);
-    locationDialog.expect.element("@useMyLocationButtonContent").text.to.equal(locationDialog.props.useMyLocationText);
-    locationDialog.expect.element("@actionText").text.to.equal(locationDialog.props.actionText);
+    locationDialog.expect.element("@useMyLocationButtonContent").text.to.match(locationDialog.props.useMyLocationText);
+    locationDialog.expect.element("@actionText").text.to.match(locationDialog.props.actionText);
 
     browser.sendKeys("html", browser.Keys.ESCAPE); 
     this.app.expect.element("@locationDialog").to.not.be.present;
@@ -153,20 +154,20 @@ const tests: GreenCometTests = {
     const folderView = this.sections.folderView;
     folderView.click("@expandRow");
     folderView.expect.elements("@folderItem").count.to.equal(0);
-    folderView.expect.element("@expandHeader").text.to.equal(folderView.props.contractedHeaderText);
-    folderView.expect.element("@expandChevron").to.have.property("classList").contain("fa-chevron-down");
+    folderView.expect.element("@expandHeader").text.to.match(folderView.props.contractedHeaderText);
+    folderView.expect.element("@expandChevron").to.have.attribute("data-icon", "chevron-down");
 
     folderView.click("@expandRow");
     folderView.expect.elements("@folderItem").count.to.equal(folderView.props.folderImageCount);
     folderView.expect.element("@expandHeader").text.to.match(folderView.props.expandedHeaderText);
-    folderView.expect.element("@expandChevron").to.have.property("classList").contain("fa-chevron-up");
+    folderView.expect.element("@expandChevron").to.have.attribute("data-icon", "chevron-up");
   },
 
   'Control Panel': function() {
     const controls = this.sections.controls;
 
     controls.click("@openCloseButton");
-    controls.expect.element("@openCloseButton").to.have.property("classList").contain("fa-gear");
+    controls.expect.element("@openCloseButton").to.have.attribute("data-icon", "gear");
     expectAllNotPresent(controls, [
       "@gridInput", "@constellationsInput", "@horizonInput",
       "@selectedLocationTimeLabel", "@selectedLocationTimeInput",
@@ -174,7 +175,7 @@ const tests: GreenCometTests = {
     ]);
 
     controls.click("@openCloseButton");
-    controls.expect.element("@openCloseButton").to.have.property("classList").contain("fa-chevron-down");
+    controls.expect.element("@openCloseButton").to.have.attribute("data-icon", "chevron-down");
     expectAllVisible(controls, [
       "@topRow", "@openCloseButton",
       "@gridCheckbox", "@constellationsCheckbox", "@horizonCheckbox",

--- a/tests/green-comet/basic.ts
+++ b/tests/green-comet/basic.ts
@@ -64,7 +64,7 @@ const tests: GreenCometTests = {
     
     const folderView = this.sections.folderView;
     folderView.expect.elements("@folderItem").count.to.equal(folderView.props.folderImageCount);
-    folderView.expect.element("@expandHeader").text.to.equal(folderView.props.expandedHeaderText);
+    folderView.expect.element("@expandHeader").text.to.match(folderView.props.expandedHeaderText);
     folderView.expect.element("@expandChevron").to.have.property("classList").contain("fa-chevron-up");
 
     const controls = this.sections.controls;
@@ -158,7 +158,7 @@ const tests: GreenCometTests = {
 
     folderView.click("@expandRow");
     folderView.expect.elements("@folderItem").count.to.equal(folderView.props.folderImageCount);
-    folderView.expect.element("@expandHeader").text.to.equal(folderView.props.expandedHeaderText);
+    folderView.expect.element("@expandHeader").text.to.match(folderView.props.expandedHeaderText);
     folderView.expect.element("@expandChevron").to.have.property("classList").contain("fa-chevron-up");
   },
 

--- a/tests/page_objects/GreenComet.ts
+++ b/tests/page_objects/GreenComet.ts
@@ -4,6 +4,8 @@ import {
   PageObjectModel
 } from "nightwatch";
 
+import { escapeRegExp } from "../utils";
+
 const greenCometCommands = {
   waitForReady(this: EnhancedPageObject): EnhancedPageObject {
     return this
@@ -121,7 +123,7 @@ const folderView = {
     }
   },
   props: {
-    expandedHeaderText: "Click thumbnail to see image in sky",
+    expandedHeaderText: new RegExp(`(\\s+)?${escapeRegExp("Click thumbnail to see image in sky")}(\\s+)?`),
     contractedHeaderText: "Image Controls",
     folderImageCount: 16
   }

--- a/tests/page_objects/GreenComet.ts
+++ b/tests/page_objects/GreenComet.ts
@@ -98,7 +98,7 @@ const locationDialog = {
   },
   props: {
     actionText: whitespacePaddedRegex("Move around the map and double-click to change location"),
-    useMyLocationText: whitespacePaddedRegex("Use My Location")
+    useMyLocationText: whitespacePaddedRegex("Use My Location", "i")
   }
 };
 
@@ -190,8 +190,8 @@ const controls = {
   },
   props: {
     selectedLocationTimeText: whitespacePaddedRegex("Selected location's time:"),
-    centerOnNowText: /Center on Now/i,
-    playCometImagesText: /Play comet images/i 
+    centerOnNowText: whitespacePaddedRegex("Center on Now", "i"),
+    playCometImagesText: whitespacePaddedRegex("Play comet images", "i")
   }
 };
 

--- a/tests/page_objects/GreenComet.ts
+++ b/tests/page_objects/GreenComet.ts
@@ -4,7 +4,7 @@ import {
   PageObjectModel
 } from "nightwatch";
 
-import { escapeRegExp } from "../utils";
+import { whitespacePaddedRegex } from "../utils";
 
 const greenCometCommands = {
   waitForReady(this: EnhancedPageObject): EnhancedPageObject {
@@ -97,8 +97,8 @@ const locationDialog = {
     }
   },
   props: {
-    actionText: "Move around the map and double-click to change location",
-    useMyLocationText: "Use My Location".toUpperCase()
+    actionText: whitespacePaddedRegex("Move around the map and double-click to change location"),
+    useMyLocationText: whitespacePaddedRegex("Use My Location")
   }
 };
 
@@ -123,8 +123,8 @@ const folderView = {
     }
   },
   props: {
-    expandedHeaderText: new RegExp(`(\\s+)?${escapeRegExp("Click thumbnail to see image in sky")}(\\s+)?`),
-    contractedHeaderText: "Image Controls",
+    expandedHeaderText: whitespacePaddedRegex("Click thumbnail to see image in sky"),
+    contractedHeaderText: whitespacePaddedRegex("Image Controls"),
     folderImageCount: 16
   }
 };
@@ -189,9 +189,9 @@ const controls = {
     }
   },
   props: {
-    selectedLocationTimeText: "Selected location's time:",
-    centerOnNowText: "Center on Now".toUpperCase(),
-    playCometImagesText: "Play comet images".toUpperCase()
+    selectedLocationTimeText: whitespacePaddedRegex("Selected location's time:"),
+    centerOnNowText: /Center on Now/i,
+    playCometImagesText: /Play comet images/i 
   }
 };
 

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -39,8 +39,13 @@ export function escapeRegExp(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
 }
 
+function regexSource(item: string | RegExp): string {
+  return typeof item === "string" ? escapeRegExp(item) : item.source;
+}
+
 // Safari likes to add whitespace at the beginning/end of strings,
 // presumably for layout/sizing purposes?
-export function whitespacePaddedRegex(str: string): RegExp {
-  return new RegExp(`(\\s+)?${escapeRegExp(str)}(\\s+)?`);
+export function whitespacePaddedRegex(base: string | RegExp, flags?: string): RegExp {
+  const source = regexSource(base);
+  return new RegExp(`(\\s+)?${source}(\\s+)?`, flags);
 }

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -38,3 +38,9 @@ export function nthOfTypeSelector(selector: string, n: number): string {
 export function escapeRegExp(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
 }
+
+// Safari likes to add whitespace at the beginning/end of strings,
+// presumably for layout/sizing purposes?
+export function whitespacePaddedRegex(str: string): RegExp {
+  return new RegExp(`(\\s+)?${escapeRegExp(str)}(\\s+)?`);
+}


### PR DESCRIPTION
Safari sometimes likes to add whitespace to the beginning or end of element text, presumably to help with layout sizing. This PR is meant to work around that by using regexes to allow things to pass if such whitespace is present.