### PR TITLE
Update where workflows look for tests

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -74,7 +74,7 @@ jobs:
           workspaces=(${{ steps.workspaces.outputs.value }})
           for ws in "${workspaces[@]}"
           do
-            if [[ $ws != 'common' && $ws != 'tests' && -d $ws ]]
+            if [[ $ws != 'common' && $ws != 'tests' && -d tests/${ws} ]]
             then
               mv ${ws}/dist dist/${ws}
             fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
           workspaces=(${{ steps.workspaces.outputs.value }})
           for ws in "${workspaces[@]}"
           do
-            if [[ $ws != 'common' && $ws != 'tests' && -d $ws ]]
+            if [[ $ws != 'common' && $ws != 'tests' && -d tests/${ws} ]]
             then
               cd $ws
               yarn serve &


### PR DESCRIPTION
Currently the workflow files are checking whether the workspace directory exists (rather than a test directory) to determine whether it should run BrowerStack tests. This PR fixes that.