### PR TITLE
Fix-camera-movement

### DIFF
--- a/m101-supernova/src/M101SN.vue
+++ b/m101-supernova/src/M101SN.vue
@@ -2085,7 +2085,7 @@ export default defineComponent({
       }
     },
 
-    showImagesetByName(name: string): boolean {
+    showImagesetByName(name: string, moveTo = false): boolean {
       const imagesetNames = Object.keys(this.imagesetLayers);
       let shown = false;
       imagesetNames.forEach((iname: string) => {
@@ -2093,6 +2093,8 @@ export default defineComponent({
           this.setLayerOpacityForImageSet(iname, 0);
         } else {
           this.setLayerOpacityForImageSet(iname, 1);
+          this.currentLayer = this.imagesetLayers[iname];
+          this.currentOpacity = 1;
           shown = true;
           // need to get the Place object for the image set and use it to set the view
           if (this.imagesetFolder != null) {
@@ -2102,6 +2104,9 @@ export default defineComponent({
               this.incomingItemSelect = place[0];
             }
           }
+          
+          if (!moveTo) { return; }
+          
           const iset = this.wwtControl.getImagesetByName(iname);
           const place = this.places[iname];
           if (iset == null) { return; }
@@ -2110,7 +2115,7 @@ export default defineComponent({
             this.gotoRADecZoom({
               raRad: D2R * place.get_RA() * 15,
               decRad: D2R * place.get_dec(),
-              zoomDeg: this.needToZoomIn(place, 2.5) ? place.get_zoomLevel() : this.wwtZoomDeg,
+              zoomDeg: this.optionalZoom(place),
               instant: true
             });
           });
@@ -2120,15 +2125,19 @@ export default defineComponent({
       return shown;
     },
     
-    showImageForDateTime(date: Date): boolean {
+    showImageForDateTime(date: Date, moveTo = false): boolean {
       const name = this.matchImageSetName(date);
       if (name == null || name == '') {
         // this.incomingItemSelect = null;
         return false;
       }
-      this.currentLayer = this.imagesetLayers[name];
-      this.currentOpacity = 1;
-      return this.showImagesetByName(name);
+      
+      if ((this.incomingItemSelect?.get_name() == name) && (!this.viewIsBad(this.places[name]))) {
+        // console.log('image already shown and view is good, so it has been "shown"');
+        return true;
+      }
+
+      return this.showImagesetByName(name, moveTo);
 
     },
 

--- a/m101-supernova/src/M101SN.vue
+++ b/m101-supernova/src/M101SN.vue
@@ -977,7 +977,7 @@ export default defineComponent({
       currentOpacity: 0,
       
       incomingItemSelect: null as Thumbnail | null,
-      m101Position: {ra: 210.802, dec: 54.348, zoom: 7.75},
+      intialPosition: {ra: 210.802, dec: 54.348, zoom: 7.75},
 
       chartXOffset: 0,
 
@@ -2134,23 +2134,18 @@ export default defineComponent({
 
     
     centerView(_options?: MoveOptions) {
-      const firstPlace = this.places[Object.keys(this.places)[0]];
+      
       this.gotoRADecZoom({
-        raRad: this.m101Position.ra * D2R,
-        decRad: this.m101Position.dec * D2R,
-        zoomDeg: firstPlace.get_zoomLevel()*6,
+        raRad: this.intialPosition.ra * D2R,
+        decRad: this.intialPosition.dec * D2R,
+        zoomDeg: this.intialPosition.zoom,
         instant: false,
       });
       // show the first image
-      this.selectedTime = this.imageDates[0];
-      this.onTimeSliderChange({zoomDeg: firstPlace.get_zoomLevel()});
-      // const now = new Date();
-      // const hours = now.getUTCHours() + (this.selectedTimezoneOffset) / (1000 * 60 * 60);
-      // this.timeOfDay = { hours: hours, minutes: now.getMinutes(), seconds: now.getSeconds() };
-      // this.selectedTime = this.binarySearch(this.dates, now.getTime());
-      // this.$nextTick(() => {
-      //   this.updateViewForDate(options);
-      // });
+      if (!this.playing) {
+        this.selectedTime = this.imageDates[0];
+        this.onTimeSliderChange({ zoomDeg: this.intialPosition.zoom });
+      }
     },
 
     updateForDateTime() {

--- a/m101-supernova/src/M101SN.vue
+++ b/m101-supernova/src/M101SN.vue
@@ -2309,7 +2309,7 @@ export default defineComponent({
       }
     },
 
-    playingCometPath(play: boolean) {
+    playingImagePath(play: boolean) {
       this.clearPlayingInterval();
       if (!play) {
         return;
@@ -2321,7 +2321,7 @@ export default defineComponent({
         this.selectedTime = minTime;
       }
 
-      this.updateViewForDate({ zoomDeg: 60 });
+      this.updateViewForDate({ zoomDeg: this.intialPosition.zoom });
 
       this.playingIntervalId = setInterval(() => {
         if (this.playingWaitCount > 0) {

--- a/m101-supernova/src/M101SN.vue
+++ b/m101-supernova/src/M101SN.vue
@@ -2302,7 +2302,7 @@ export default defineComponent({
           }
           this.$nextTick(() => {
             this.showImageForDateTime(this.dateTime);
-            this.updateViewForDate();
+            // this.updateViewForDate();
           });
         }, 100);
       }

--- a/m101-supernova/src/M101SN.vue
+++ b/m101-supernova/src/M101SN.vue
@@ -358,7 +358,7 @@
             :data="dates"
             tooltip="always"
             tooltip-placement="top"
-            tooltip-style="opacity: 0.75"
+            :tooltip-style="{opacity: 0.75}"
             :tooltip-formatter="(v: number) => 
               toDateString(new Date(v))
             "

--- a/m101-supernova/src/M101SN.vue
+++ b/m101-supernova/src/M101SN.vue
@@ -2170,6 +2170,14 @@ export default defineComponent({
       if (children == null) { return; }
       const place = children[0] as Place;
       this.onItemSelected(place);
+    },
+
+
+    optionalZoom(place: Place, factor = 3): number {
+      if (this.needToZoomIn(place, factor)) {
+        console.log('optionalZoom: zoom in');
+      }
+      return this.needToZoomIn(place, factor) ? place.get_zoomLevel() : this.wwtZoomDeg;
     }
   },
 

--- a/m101-supernova/src/M101SN.vue
+++ b/m101-supernova/src/M101SN.vue
@@ -935,8 +935,8 @@ export default defineComponent({
       showHorizon: false,
       outerArrow: null as Poly | null,
       innerArrow: null as Poly | null,
-      m101RADeg:  210.802,
-      m101DecDeg: 54.348,
+      m101RADeg: 3.681181581357794 * R2D,
+      m101DecDeg: 0.9480289529731357 * R2D,
 
       showSpeadSheetLater: false,
 

--- a/m101-supernova/src/M101SN.vue
+++ b/m101-supernova/src/M101SN.vue
@@ -2294,6 +2294,7 @@ export default defineComponent({
     playing(play: boolean) {
       this.clearPlayingInterval();
       if (play) {
+        this.showImageForDateTime(this.dateTime, true);
         this.playingIntervalId = setInterval(() => {
           if (this.selectedTime < maxDate) {
             this.nextDate();

--- a/m101-supernova/src/M101SN.vue
+++ b/m101-supernova/src/M101SN.vue
@@ -2172,6 +2172,29 @@ export default defineComponent({
       this.onItemSelected(place);
     },
 
+    wwtMove(options: GotoRADecZoomParams) {
+      this.$nextTick(() => {
+        this.gotoRADecZoom(options);
+      });
+    },
+
+    moveToPlace(place: Place, fovDeg = null as number | null) {
+      let zoomDeg: number;
+
+      if (fovDeg) {
+        zoomDeg = fovDeg * 6;
+      } else {
+        zoomDeg = this.optionalZoom(place);
+      }
+
+      this.wwtMove({
+        raRad: D2R * place.get_RA() * 15,
+        decRad: D2R * place.get_dec(),
+        zoomDeg: zoomDeg,
+        instant: true
+      });
+
+    },
 
     optionalZoom(place: Place, factor = 3): number {
       if (this.needToZoomIn(place, factor)) {


### PR DESCRIPTION
Main purpose of this PR is stop the play button from recentering M101. 



This also makes movement optional when displaying an image (by default this is false). It makes sense for "show" function to move by default, so a later change would be make separate "get" and "show" functions for images. 