### PR TITLE
Move gallery to common and CSS tweaks

### DIFF
--- a/common/src/components/Gallery.vue
+++ b/common/src/components/Gallery.vue
@@ -193,7 +193,7 @@ export default defineComponent({
 
 </script>
 
-<style scoped lang="less">
+<style lang="less">
 .blurred {
   background: transparent;
   box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);

--- a/common/src/components/Gallery.vue
+++ b/common/src/components/Gallery.vue
@@ -194,114 +194,115 @@ export default defineComponent({
 </script>
 
 <style lang="less">
-.blurred {
-  background: transparent;
-  box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
-  backdrop-filter: blur(6px);
-}
-
 .gallery-root {
   transition-property: height, width;
   transition: 0.5s ease-out;
-}
 
-.gallery {
-  border-radius: 5px;
-  border: 1px solid white;
-  display: flex;
-  flex-direction: column;
-  overflow-y: auto;
-  max-height: var(--gallery-max-height);
-  width: min(calc(var(--gallery-width)), calc(100%));
+  .blurred {
+    background: transparent;
+    box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
+    backdrop-filter: blur(6px);
+  }
 
-  // Better way to do this?
+  .gallery {
+    border-radius: 5px;
+    border: 1px solid white;
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
+    max-height: var(--gallery-max-height);
+    width: min(calc(var(--gallery-width)), calc(100%));
+
+    // Better way to do this?
   position: fixed;
   left: 50%;
   transform: translateX(-50%);
-}
+  }
 
-.noselect {
-  user-select: none;
-  -webkit-user-select: none;
-  -ms-user-select: none;
-}
+  .noselect {
+    user-select: none;
+    -webkit-user-select: none;
+    -ms-user-select: none;
+  }
 
-.gallery-header {
-  position: relative;
-  display: flex;
-  justify-content: center;
-}
+  .gallery-header {
+    position: relative;
+    display: flex;
+    justify-content: center;
+  }
 
-.gallery-title {
-  font-size: 16pt;
-}
+  .gallery-title {
+    font-size: 16pt;
+  }
 
-.gallery-close {
-  position: absolute;
-  right: 3px;
-  cursor: pointer;
-}
+  .gallery-close {
+    position: absolute;
+    right: 3px;
+    cursor: pointer;
+  }
 
-.gallery-content {
-  display: grid;
-  grid-template-columns: repeat(var(--column-count), minmax(100px, 1fr));
-  column-gap: 10px;
-  row-gap: 5px;
-  padding: 5px
-}
+  .gallery-content {
+    display: grid;
+    grid-template-columns: repeat(var(--column-count), minmax(100px, 1fr));
+    column-gap: 10px;
+    row-gap: 5px;
+    padding: 5px
+  }
 
-.default-activator {
-  border-radius: 3px;
-  border: solid 1px white;
-  position: relative;
-  height: fit-content;
-  width: fit-content;
-  display: flex;
-  flex-direction: column;
-  cursor: pointer;
-
-  img {
-    padding: 5px;
+  .default-activator {
     border-radius: 3px;
+    border: solid 1px white;
+    position: relative;
+    height: fit-content;
+    width: fit-content;
+    display: flex;
+    flex-direction: column;
+    cursor: pointer;
+
+    img {
+      padding: 5px;
+      border-radius: 3px;
+    }
   }
-}
 
-.default-activator-title {
-  margin: auto;
-}
+  .default-activator-title {
+    margin: auto;
+  }
 
-.gallery-item {
-  border-radius: 3px;
-  border: 1px solid white;
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  cursor: pointer;
-
-  img {
-    margin-left: auto;
-    margin-right: auto;
+  .gallery-item {
     border-radius: 3px;
+    border: 1px solid white;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    cursor: pointer;
+
+    img {
+      margin-left: auto;
+      margin-right: auto;
+      border-radius: 3px;
+    }
+
+    span {
+      flex-grow: 1;
+      display: inline-grid;
+      align-items: center;
+      text-align: center;
+    }
   }
 
-  span {
-    flex-grow: 1;
-    display: inline-grid;
-    align-items: center;
-    text-align: center;
+  .selected {
+    border: 1px solid var(--selected-color);
+
+    span {
+      color: var(--selected-color);
+    }
   }
-}
 
-.selected {
-  border: 1px solid var(--selected-color);
-
-  span {
-    color: var(--selected-color);
+  .place-name {
+    font-size: 10pt;
   }
-}
 
-.place-name {
-  font-size: 10pt;
 }
 </style>
 

--- a/common/src/components/IconButton.vue
+++ b/common/src/components/IconButton.vue
@@ -120,13 +120,13 @@ export default defineComponent({
     color: var(--focus-color);
     border-color: var(--focus-color);
   }
-}
 
-.active { 
-  box-shadow: 0px 0px 10px 3px var(--color);
+  &.active {
+    box-shadow: 0px 0px 10px 3px var(--color);
 
-  &:focus {
-    box-shadow: 0px 0px 10px 3px var(--focus-color);
+    &:focus {
+      box-shadow: 0px 0px 10px 3px var(--focus-color);
+    }
   }
 }
 </style>

--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -2,13 +2,13 @@ import { KeyboardControlSettings } from "./keyboard";
 import MiniDSBase from "./components/MiniDSBase";
 import IconButton from "./components/IconButton.vue";
 import { BackgroundImageset, skyBackgroundImagesets } from "./background";
-//import Gallery from "./components/Gallery.vue";
+import Gallery from "./components/Gallery.vue";
 
 export {
   BackgroundImageset,
   KeyboardControlSettings,
   MiniDSBase,
-  //Gallery,
+  Gallery,
   IconButton,
   skyBackgroundImagesets
 };

--- a/common/vue.config.js
+++ b/common/vue.config.js
@@ -23,6 +23,17 @@ module.exports = defineConfig({
           return opts;
         });
     }
+
+    // Keep the very big WWT engine external
+    config.externals({
+      '@wwtelescope/engine': {
+        'amd': '@wwtelescope/engine', // typeof define === 'function' && define.amd
+        'commonjs2': '@wwtelescope/engine', // typeof exports === 'object' && typeof module === 'object'
+        'commonjs': '@wwtelescope/engine', // typeof exports === 'object'
+        'root': 'wwtlib' // none of the above: browser mode using global variables
+      }
+    });
+
   },
 
   // TODO: For some reason we're having trouble loading chunks

--- a/m101-supernova/src/main.ts
+++ b/m101-supernova/src/main.ts
@@ -11,8 +11,7 @@ import d3Scatter from "./d3-scatter.vue";
 import ConstellationIcon from "./ConstellationIcon.vue";
 import { IconButton } from "@minids/common";
 
-import Gallery from "./Gallery.vue";
-// import { Gallery } from "@minids/common";
+import { Gallery } from "@minids/common";
 
 import "./polyfills";
 


### PR DESCRIPTION
This PR moves the image gallery component from #108 into the `common` package, since I imagine that we'll want to use that in other stories as well. This PR also rearranges the CSS inside the common components to attempt to minimize the impact of https://github.com/vuejs/vue-loader/issues/1915, which forces us to use non-scoped styling.

Again, no CI on dev, but BrowserStack is passing locally for me.