### PR TITLE
Add integrated arrows

### DIFF
--- a/m101-supernova/src/M101SN.vue
+++ b/m101-supernova/src/M101SN.vue
@@ -2512,16 +2512,16 @@ body {
   margin-bottom: -33px;
   
   // makes the y-axis border look like an arrow
-  #plot::before {
-    content: "^";
-    position: absolute;
-    font-size: 1.5rem;
-    font-weight: bold;
-    // transform: translateX(-.51em) translateY(-.55em);
-    transform: translateX(-.14rem) translateY(-.52rem);
-    transform-origin: 0 0;
-    pointer-events: none;
-  }
+  // #plot::before {
+  //   content: "^";
+  //   position: absolute;
+  //   font-size: 1.5rem;
+  //   font-weight: bold;
+  //   // transform: translateX(-.51em) translateY(-.55em);
+  //   transform: translateX(-.14rem) translateY(-.52rem);
+  //   transform-origin: 0 0;
+  //   pointer-events: none;
+  // }
   
   #chart-title {
     display: none;
@@ -2994,20 +2994,22 @@ video {
 #slider {
   width: 100% !important;
   margin: 5px 30px;
+  // display: none;
+  // opacity: 0;
 
   
-  &:after {
-    content: "^";
-    position: absolute;
-    right: 0;
-    line-height: 1;
-    font-size: 1.5rem;
-    font-weight: bold;
-    transform: translateX(0.36rem) translateY(-0.86rem) rotate(90deg);
-    color: #ccc;
-    transform-origin: 50% 50%;
-    pointer-events: none;
-  }
+  // &:after {
+  //   content: "^";
+  //   position: absolute;
+  //   right: 0;
+  //   line-height: 1;
+  //   font-size: 1.5rem;
+  //   font-weight: bold;
+  //   transform: translateX(0.36rem) translateY(-0.86rem) rotate(90deg);
+  //   color: #ccc;
+  //   transform-origin: 50% 50%;
+  //   pointer-events: none;
+  // }
 }
 
 #opacity-slider {

--- a/m101-supernova/src/chartjs-scatter.vue
+++ b/m101-supernova/src/chartjs-scatter.vue
@@ -191,6 +191,64 @@ export default defineComponent({
     },
     
     draw() {
+      // arrow adapted from 
+      // https://stackoverflow.com/questions/72214227/chart-js-add-direction-arrows-to-the-x-and-y-axes
+      const arrowBorder = {
+        id: 'arrowBorder',
+        afterDatasetsDraw(chart: Chart, args: any, pluginOptions: any) {
+          const {
+            ctx,
+            chartArea: {
+              top,
+              bottom,
+              left,
+              right,
+              width,
+              height
+            }
+          } = chart;
+
+
+          
+          ctx.save();
+          ctx.beginPath();
+          ctx.lineWidth = pluginOptions.yWidth;
+          ctx.strokeStyle = "white";
+
+          const headLength = 6;
+          const headWidth = 5;
+
+          const arrowUpTip = -4;
+          // stem
+          ctx.moveTo(left, bottom + 1);
+          ctx.lineTo(left, top + arrowUpTip);
+          // arrowhead
+          ctx.moveTo(left - headWidth, top + arrowUpTip + headLength);
+          ctx.lineTo(left, top + arrowUpTip);
+          ctx.lineTo(left + headWidth, top + arrowUpTip + headLength);
+          ctx.stroke();
+          ctx.closePath();
+          // 
+
+          ctx.beginPath();
+          ctx.lineWidth = pluginOptions.xWidth;
+          ctx.strokeStyle = "#ccc";
+          const arrowRightTip = 4;
+          // stem
+          ctx.moveTo(left-1, bottom);
+          ctx.lineTo(right + arrowRightTip, bottom);
+          // arrowhead
+          ctx.moveTo(right + arrowRightTip - headLength, bottom - headWidth);
+          ctx.lineTo(right + arrowRightTip, bottom);
+          ctx.lineTo(right + arrowRightTip - headLength, bottom + headWidth);
+          ctx.stroke();
+          ctx.closePath();
+        },
+        defaults: {
+          yWidth: this.chartOptions.scales.y.border.width - 1,
+          xWidth: this.chartOptions.scales.x.border.width - 1,
+        }
+      };
       
       const ctx = this.$el.querySelector("#chartjs");
       
@@ -205,6 +263,7 @@ export default defineComponent({
   
         data: this.chartData,
         options: this.chartOptions,
+        plugins: [arrowBorder],
         
       });
 
@@ -325,6 +384,7 @@ export default defineComponent({
             min: this.xrange[0],
             max: this.xrange[1],
             reverse: this.reversedX,
+            width: 3,
             ...this.axisOptions,
             ...this.xAxisOptions,
           },
@@ -335,6 +395,7 @@ export default defineComponent({
             reverse: this.reversedY,
             min: this.computedYRange[0],
             max: this.computedYRange[1],
+            width: 3,
             ...this.axisOptions,
             ...this.yAxisOptions,
             


### PR DESCRIPTION
Arrows are now drawn on the canvas chart. The previous arrow psuedo-elements failed  on mobile browsers (but not in devtools mobile simulation). 