### PR TITLE
Allow arrow annotation to be rotated

### DIFF
--- a/m101-supernova/src/M101SN.vue
+++ b/m101-supernova/src/M101SN.vue
@@ -652,10 +652,7 @@ interface MoveOptions {
   rollRad?: number;
 }
 
-// import {
-//   ephemerisFullDatesCsv,
-//   ephemerisImageDatesCsv
-// } from "./data";
+type Point = [number, number];
 
 import {
   m101DataList,
@@ -872,7 +869,7 @@ export default defineComponent({
       currentOpacity: 0,
       
       incomingItemSelect: null as Thumbnail | null,
-      intialPosition: {ra: 210.802, dec: 54.348, zoom: 7.75},
+      initialPosition: {ra: 210.802, dec: 54.348, zoom: 7.75},
 
       chartBounds: {} as {
         'bounds': { xmin: number, xmax: number, ymin: number, ymax: number },
@@ -1020,9 +1017,9 @@ export default defineComponent({
       }, 100);
 
       this.gotoRADecZoom({
-        raRad: D2R * this.intialPosition.ra,
-        decRad: D2R * this.intialPosition.dec,
-        zoomDeg: this.intialPosition.zoom,
+        raRad: D2R * this.initialPosition.ra,
+        decRad: D2R * this.initialPosition.dec,
+        zoomDeg: 2,
         instant: true
       });
 
@@ -1031,6 +1028,12 @@ export default defineComponent({
         if (this.showArrow) {
           this.displayArrow();
         }
+        this.gotoRADecZoom({
+          raRad: this.wwtRARad,
+          decRad: this.wwtDecRad,
+          zoomDeg: this.initialPosition.zoom,
+          instant: true
+        });
       }, 100);
 
     });
@@ -1180,7 +1183,7 @@ export default defineComponent({
       return;
     },
 
-    rotatePoint(point: [number, number], origin: [number, number], angleDeg: number): [number, number] {
+    rotatePoint(point: Point, origin: Point, angleDeg: number): Point {
       const xp = point[0] - origin[0];
       const yp = point[1] - origin[1];
       const angleRad = angleDeg * D2R;
@@ -1193,11 +1196,11 @@ export default defineComponent({
     createArrow() {
 
       const m101XY = this.findScreenPointForRADec({ra: this.m101RADeg, dec: this.m101DecDeg});
-      const m101Point: [number, number] = [m101XY.x, m101XY.y];
+      const m101Point: Point = [m101XY.x, m101XY.y];
     
       // Create the outer (purple) arrow
       this.outerArrow = new Poly();
-      const outerArrowCoordinates: [number, number][] = [];
+      const outerArrowCoordinates: Point[] = [];
 
       const pointRA = this.m101RADeg;
       const centerDec = this.m101DecDeg;
@@ -1234,7 +1237,7 @@ export default defineComponent({
       
       // Create the inner (white) arrow
       this.innerArrow = new Poly();
-      const innerArrowCoordinates: [number, number][] = [];
+      const innerArrowCoordinates: Point[] = [];
       
       const delta = 0.002; // The thickness of the outer "border"
       const headSlope = (topDec - centerDec) / (headBackRA - pointRA);
@@ -2154,15 +2157,15 @@ export default defineComponent({
     centerView(_options?: MoveOptions) {
       
       this.gotoRADecZoom({
-        raRad: this.intialPosition.ra * D2R,
-        decRad: this.intialPosition.dec * D2R,
-        zoomDeg: this.intialPosition.zoom,
+        raRad: this.initialPosition.ra * D2R,
+        decRad: this.initialPosition.dec * D2R,
+        zoomDeg: this.initialPosition.zoom,
         instant: false,
       });
       // show the first image
       if (!this.playing) {
         this.selectedTime = this.imageDates[0];
-        this.onTimeSliderChange({ zoomDeg: this.intialPosition.zoom });
+        this.onTimeSliderChange({ zoomDeg: this.initialPosition.zoom });
       }
     },
 
@@ -2339,7 +2342,7 @@ export default defineComponent({
         this.selectedTime = minTime;
       }
 
-      this.updateViewForDate({ zoomDeg: this.intialPosition.zoom });
+      this.updateViewForDate({ zoomDeg: this.initialPosition.zoom });
 
       this.playingIntervalId = setInterval(() => {
         if (this.playingWaitCount > 0) {

--- a/m101-supernova/src/M101SN.vue
+++ b/m101-supernova/src/M101SN.vue
@@ -1221,16 +1221,10 @@ export default defineComponent({
       outerArrowCoordinates.push([headBackRA, bottomDec]);
 
       for (const coords of outerArrowCoordinates) {
-        console.log(m101Point);
-        console.log(coords);
         const point = this.findScreenPointForRADec({ra: coords[0], dec: coords[1]});
-        console.log(point);
         const rotatedPoint = this.rotatePoint([point.x, point.y], m101Point, this.arrowAngleDeg);
-        console.log(rotatedPoint);
         const rotatedCoords = this.findRADecForScreenPoint({x: rotatedPoint[0], y: rotatedPoint[1]});
-        console.log(rotatedCoords);
         this.outerArrow.addPoint(rotatedCoords.ra, rotatedCoords.dec);
-        console.log("=======");
       }
 
 

--- a/m101-supernova/src/M101SN.vue
+++ b/m101-supernova/src/M101SN.vue
@@ -830,9 +830,9 @@ export default defineComponent({
       showHorizon: false,
       outerArrow: null as Poly | null,
       innerArrow: null as Poly | null,
-      m101RADeg: 3.681181581357794 * R2D,
-      m101DecDeg: 0.9480289529731357 * R2D,
-      arrowAngleDeg: 25,
+      m101RADeg: 3.681181581357794 * R2D + 0.2/60,
+      m101DecDeg: 0.9480289529731357 * R2D - 1/60,
+      arrowAngleDeg: -60,
 
       showSpeadSheetLater: false,
 
@@ -1199,7 +1199,7 @@ export default defineComponent({
       this.outerArrow = new Poly();
       const outerArrowCoordinates: [number, number][] = [];
 
-      const pointRA = this.m101RADeg + 0.05;
+      const pointRA = this.m101RADeg;
       const centerDec = this.m101DecDeg;
       const arrowHalfHeight = 0.02;
       const stemFraction = 0.4;

--- a/m101-supernova/src/M101SN.vue
+++ b/m101-supernova/src/M101SN.vue
@@ -832,6 +832,7 @@ export default defineComponent({
       innerArrow: null as Poly | null,
       m101RADeg: 3.681181581357794 * R2D,
       m101DecDeg: 0.9480289529731357 * R2D,
+      arrowAngleDeg: 25,
 
       showSpeadSheetLater: false,
 
@@ -1177,10 +1178,21 @@ export default defineComponent({
       return;
     },
 
+    rotatePoint(point: [number, number], angleDeg: number): [number, number] {
+      const xp = point[0] - this.m101RADeg;
+      const yp = point[1] - this.m101DecDeg;
+      const angleRad = angleDeg * D2R;
+      return [
+        this.m101RADeg + xp * Math.cos(angleRad) - yp * Math.sin(angleRad),
+        this.m101DecDeg + xp * Math.sin(angleRad) + yp * Math.cos(angleRad)
+      ];
+    },
+
     createArrow() {
     
       // Create the outer (purple) arrow
       this.outerArrow = new Poly();
+      const outerArrowPoints: [number, number][] = [];
 
       const pointRA = this.m101RADeg + 0.05;
       const centerDec = this.m101DecDeg;
@@ -1195,13 +1207,17 @@ export default defineComponent({
       const stemHalfHeight = stemFraction * arrowHalfHeight;
       const stemTopDec = centerDec + stemHalfHeight;
       const stemBottomDec = centerDec - stemHalfHeight;
-      this.outerArrow.addPoint(pointRA, centerDec);
-      this.outerArrow.addPoint(headBackRA, topDec);
-      this.outerArrow.addPoint(headBackRA, stemTopDec);
-      this.outerArrow.addPoint(stemBackRA, stemTopDec);
-      this.outerArrow.addPoint(stemBackRA, stemBottomDec);
-      this.outerArrow.addPoint(headBackRA, stemBottomDec);
-      this.outerArrow.addPoint(headBackRA, bottomDec);
+      outerArrowPoints.push([pointRA, centerDec]);
+      outerArrowPoints.push([headBackRA, topDec]);
+      outerArrowPoints.push([headBackRA, stemTopDec]);
+      outerArrowPoints.push([stemBackRA, stemTopDec]);
+      outerArrowPoints.push([stemBackRA, stemBottomDec]);
+      outerArrowPoints.push([headBackRA, stemBottomDec]);
+      outerArrowPoints.push([headBackRA, bottomDec]);
+
+      for (const point of outerArrowPoints) {
+        this.outerArrow.addPoint(...this.rotatePoint(point, this.arrowAngleDeg));
+      }
 
       this.outerArrow.set_lineColor(this.accentColor);
       this.outerArrow.set_fillColor(this.accentColor);
@@ -1209,6 +1225,7 @@ export default defineComponent({
       
       // Create the inner (white) arrow
       this.innerArrow = new Poly();
+      const innerArrowPoints: [number, number][] = [];
       
       const delta = 0.002; // The thickness of the outer "border"
       const headSlope = (topDec - centerDec) / (headBackRA - pointRA);
@@ -1219,13 +1236,17 @@ export default defineComponent({
       const innerBottomDec = 2 * centerDec - innerTopDec;
       const innerStemTopDec = stemTopDec - 0.75 * delta;
       const innerStemBottomDec = stemBottomDec + 0.75 * delta;
-      this.innerArrow.addPoint(innerPointRA, centerDec);
-      this.innerArrow.addPoint(innerHeadBackRA, innerTopDec); 
-      this.innerArrow.addPoint(innerHeadBackRA, innerStemTopDec);
-      this.innerArrow.addPoint(innerStemBackRA, innerStemTopDec); 
-      this.innerArrow.addPoint(innerStemBackRA, innerStemBottomDec);
-      this.innerArrow.addPoint(innerHeadBackRA, innerStemBottomDec);
-      this.innerArrow.addPoint(innerHeadBackRA, innerBottomDec);
+      innerArrowPoints.push([innerPointRA, centerDec]);
+      innerArrowPoints.push([innerHeadBackRA, innerTopDec]); 
+      innerArrowPoints.push([innerHeadBackRA, innerStemTopDec]);
+      innerArrowPoints.push([innerStemBackRA, innerStemTopDec]); 
+      innerArrowPoints.push([innerStemBackRA, innerStemBottomDec]);
+      innerArrowPoints.push([innerHeadBackRA, innerStemBottomDec]);
+      innerArrowPoints.push([innerHeadBackRA, innerBottomDec]);
+
+      for (const point of innerArrowPoints) {
+        this.innerArrow.addPoint(...this.rotatePoint(point, this.arrowAngleDeg));
+      }
 
       const innerColor = "#ffffff";
       this.innerArrow.set_lineColor(innerColor);


### PR DESCRIPTION
This PR allows the arrow annotation to be rotated. This ended up being a bit trickier than I had expected, but the basic idea to to leverage the built in WWT ability to convert from pixel <---> sky coordinates to do the rotation in pixel coordinates (which are flat), then convert back to sky coordinates. (Performing the rotation in sky coordinates directly leads to a sheared arrow). This necessitates drawing the arrow after the WWT view arrives at M101 during setup.

I don't know what angle we want the arrow to be rotated by, but once we decide I can do any final tweaks to make it look better.