### PR TITLE
Long-press tooltip for icon buttons

### DIFF
--- a/common/src/components/IconButton.vue
+++ b/common/src/components/IconButton.vue
@@ -15,6 +15,8 @@
         :class="['icon-wrapper', {'active': modelValue}]"
         @click="handleAction"
         @keyup.enter="handleAction"
+        @touchstart="handleTouchStart"
+        @touchend="handleTouchEnd"
         :style="cssVars"
         tabindex="0"
       >
@@ -51,6 +53,7 @@ export default defineComponent({
     focusColor: { type: String, default: "#ffffff" },
     backgroundColor: { type: String, default: "#040404" },
     border: { type: Boolean, default: true },
+    longPressTimeMs: { type: Number, default: 500 },
     tooltipText: { type: String, required: false },
     tooltipLocation: { type: String, default: "start" },
     tooltipOnClick: { type: Boolean, default: false },
@@ -70,6 +73,20 @@ export default defineComponent({
     handleAction() {
       this.updateValue();
       this.$emit('activate');
+    },
+
+    handleTouchStart() {
+      this.longPressTimeout = setTimeout(() => {
+        this.tooltip = true;
+      }, this.longPressTimeMs);
+    },
+
+    handleTouchEnd() {
+      if (this.longPressTimeout) {
+        clearTimeout(this.longPressTimeout);
+        this.longPressTimeout = null;
+      }
+      this.tooltip = false;
     }
   },
 
@@ -77,6 +94,7 @@ export default defineComponent({
     return {
       active: false,
       tooltip: false,
+      longPressTimeout: null as ReturnType<typeof setTimeout> | null
     };
   },
 


### PR DESCRIPTION
This PR modifies the icon button component so that the tooltip displays when it is long-pressed on a touchscreen (500ms by default, but can be modified via a prop).