### PR TITLE
Update gallery CSS

### DIFF
--- a/common/src/components/Gallery.vue
+++ b/common/src/components/Gallery.vue
@@ -273,7 +273,6 @@ export default defineComponent({
   .gallery-item {
     border-radius: 3px;
     border: 1px solid white;
-    height: 100%;
     display: flex;
     flex-direction: column;
     cursor: pointer;

--- a/pinwheel-supernova/src/M101SN.vue
+++ b/pinwheel-supernova/src/M101SN.vue
@@ -83,7 +83,7 @@
           >
       </icon-button>
       </div>
-      <div id="right-buttons">
+      <div id="left-buttons">
         <icon-button
           v-model="showTextSheet"
           fa-icon="book-open"
@@ -2914,7 +2914,7 @@ div#main-content > div {
   margin-bottom: 25px;
 }
 
-#right-buttons {
+#left-buttons {
   display: flex;
   flex-direction: column;
   gap: 10px;


### PR DESCRIPTION
This PR updates some CSS in the image gallery that should fix the issue (it does on my browsers, at least) that Alyssa was seeing on (I believe) Safari where the image `Place` names weren't appearing.