### PR TITLE
Make links open in new tab

### DIFF
--- a/carina/src/Carina.vue
+++ b/carina/src/Carina.vue
@@ -126,16 +126,16 @@
 
         <div id="credits" class="ui-text">
           <div id="icons-container">
-            <a href="https://www.cosmicds.cfa.harvard.edu/"
-              ><img alt="CosmicDS Logo" src="../../assets/cosmicds_logo_for_dark_backgrounds.png"
+            <a href="https://www.cosmicds.cfa.harvard.edu/" target="_blank" rel="noopener noreferrer"
+            ><img alt="CosmicDS Logo" src="../../assets/cosmicds_logo_for_dark_backgrounds.png"
             /></a>
-            <a href="https://worldwidetelescope.org/home/"
+            <a href="https://worldwidetelescope.org/home/" target="_blank" rel="noopener noreferrer"
               ><img alt="WWT Logo" src="../../assets/logo_wwt.png"
             /></a>
-            <a href="https://science.nasa.gov/learners" class="pl-1"
+            <a href="https://science.nasa.gov/learners" target="_blank" rel="noopener noreferrer" class="pl-1"
               ><img alt="SciAct Logo" src="../../assets/logo_sciact.png"
             /></a>
-            <a href="https://nasa.gov/" target="_blank" class="pl-1"
+            <a href="https://nasa.gov/" target="_blank" rel="noopener noreferrer" class="pl-1"
               ><img alt="SciAct Logo" src="../../assets/NASA_Partner_color_300_no_outline.png"
             /></a>
             <!-- <ShareNetwork
@@ -225,7 +225,7 @@
               <v-card class="no-bottom-border-radius scrollable">
                 <v-card-text class="info-text no-bottom-border-radius">
                   <h4>Explore!</h4>
-                  As scientists, we learn by observing and noticing. Explore these images of the <a href="https://webbtelescope.org/contents/media/images/2022/031/01G77PKB8NKR7S8Z6HBXMYATGJ">Carina Nebula</a> and see what you can find.<br>
+                  As scientists, we learn by observing and noticing. Explore these images of the <a href="https://webbtelescope.org/contents/media/images/2022/031/01G77PKB8NKR7S8Z6HBXMYATGJ" target="_blank" rel="noopener noreferrer">Carina Nebula</a> and see what you can find.<br>
                   • Look for stars that are “invisible” to our eyes because they are blocked by dust but shine in JWST’s infrared image.<br>
                   • Look near the edge of the dusty, dense clouds in the JWST image. See if you can find bright yellow arcs that indicate gas and dust being blown away by young forming stars.<br>
                   • Scan the dark blue region of the JWST image and see if you can find reddish smudgy objects that might be galaxies. Switch over to the Hubble image. Do you see those galaxies in the Hubble image?<br>
@@ -236,12 +236,12 @@
                   Images show us the structure of objects in space, which here provides clues on how stars form and evolve. In the Hubble and JWST images of the Carina Nebula, you can see regions of very high density dust and gas (the brown parts of the images) where new stars are being born. If you zoom out, you will see that the images are at the edge of what appears to be a larger bubble, which is the cavern of lower density gas carved out by winds from massive stars.
                   <br><br>
                   <h4>Visible vs Infrared Light</h4>
-                  Our eyes can detect visible light, but visible light is only a small part of a broader <a href="https://hubblesite.org/contents/articles/the-electromagnetic-spectrum">spectrum</a> of light that has different energies, ranging from gamma rays and x-rays to infrared light and radio waves. Images from each part of the spectrum can tell a different part of the story about objects in space.
+                  Our eyes can detect visible light, but visible light is only a small part of a broader <a href="https://hubblesite.org/contents/articles/the-electromagnetic-spectrum" target="_blank" rel="noopener noreferrer">spectrum</a> of light that has different energies, ranging from gamma rays and x-rays to infrared light and radio waves. Images from each part of the spectrum can tell a different part of the story about objects in space.
                   <br><br>
                   The Hubble Space Telescope takes pictures in visible light, like our eyes. The James Webb Space Telescope takes pictures in infrared light. Some “night vision” cameras image objects in the dark using infrared light. Animals and people “glow” in infrared in the dark because we usually have higher temperatures than our surroundings.
                   <br><br><br>
                   <h3>Credits:</h3>
-                  <h4><a href="https://www.cosmicds.cfa.harvard.edu/">CosmicDS</a> Mini Stories Team:</h4>
+                  <h4><a href="https://www.cosmicds.cfa.harvard.edu/" target="_blank" rel="noopener noreferrer">CosmicDS</a> Mini Stories Team:</h4>
                   Jon Carifio<br>
                   John Lewis<br>
                   Pat Udomprasert<br>
@@ -295,7 +295,7 @@
                           style="min-height: 120px;"
                         >
                           <p>
-                            The frame above provides an <b>interactive view </b>of the night sky, powered by WorldWide Telescope (WWT). Here you can see a portion of the Carina Nebula imaged by the <a href="https://hubblesite.org/">Hubble Space Telescope</a> and the <a href="https://webbtelescope.org/">James Webb Space Telescope</a>. These colorful images are overlaid against a background of the whole sky.
+                            The frame above provides an <b>interactive view </b>of the night sky, powered by WorldWide Telescope (WWT). Here you can see a portion of the Carina Nebula imaged by the <a href="https://hubblesite.org/" target="_blank" rel="noopener noreferrer">Hubble Space Telescope</a> and the <a href="https://webbtelescope.org/" target="_blank" rel="noopener noreferrer">James Webb Space Telescope</a>. These colorful images are overlaid against a background of the whole sky.
                           </p>
                           <p>You can zoom out to see where these images fit within a larger cloud of gas and dust.</p>
                           <p>You can zoom in to see stunning detail within both images.</p>
@@ -306,7 +306,7 @@
                     <v-row>
                       <v-col cols="12">
                         <h3>Credits:</h3>
-                        <h4><a href="https://www.cosmicds.cfa.harvard.edu/">CosmicDS</a> Mini Stories Team:</h4>
+                        <h4><a href="https://www.cosmicds.cfa.harvard.edu/" target="_blank" rel="noopener noreferrer">CosmicDS</a> Mini Stories Team:</h4>
                         Jon Carifio<br>
                         John Lewis<br>
                         Pat Udomprasert<br>

--- a/green-comet/src/C2022E3.vue
+++ b/green-comet/src/C2022E3.vue
@@ -251,16 +251,16 @@
       </div>
       <div id="credits" class="ui-text">
         <div id="icons-container">
-          <a href="https://www.cosmicds.cfa.harvard.edu/" target="_blank"
+          <a href="https://www.cosmicds.cfa.harvard.edu/" target="_blank" rel="noopener noreferrer"
             ><img alt="CosmicDS Logo" src="../../assets/cosmicds_logo_for_dark_backgrounds.png"
           /></a>
-          <a href="https://worldwidetelescope.org/home/" target="_blank"
+          <a href="https://worldwidetelescope.org/home/" target="_blank" rel="noopener noreferrer"
             ><img alt="WWT Logo" src="../../assets/logo_wwt.png"
           /></a>
-          <a href="https://science.nasa.gov/learners" target="_blank" class="pl-1"
+          <a href="https://science.nasa.gov/learners" target="_blank" rel="noopener noreferrer" class="pl-1"
             ><img alt="SciAct Logo" src="../../assets/logo_sciact.png"
           /></a>
-          <a href="https://nasa.gov/" target="_blank" class="pl-1"
+          <a href="https://nasa.gov/" target="_blank" rel="noopener noreferrer" class="pl-1"
             ><img alt="SciAct Logo" src="../../assets/NASA_Partner_color_300_no_outline.png"
           /></a>
           <!-- <ShareNetwork
@@ -372,7 +372,7 @@
             <v-card class="no-bottom-border-radius scrollable">
               <v-card-text class="info-text no-bottom-border-radius">
                 
-                Comets are dusty snowballs, large clumps of rock and ice, that originate in the outer solar system. The “Green Comet” (or <a href="https://science.nasa.gov/comet-2022-e3-ztf" target="_blank">C/2022 E3</a>) makes its closest approach to the Sun (and to Earth) in early 2023. The comet images in this interactive view were taken on different dates from December 2022 through January 2023 by astrophotographer <a href="http://www.astrostudio.at/" target="_blank">Gerald Rhemann</a>.
+                Comets are dusty snowballs, large clumps of rock and ice, that originate in the outer solar system. The “Green Comet” (or <a href="https://science.nasa.gov/comet-2022-e3-ztf" target="_blank" rel="noopener noreferrer">C/2022 E3</a>) makes its closest approach to the Sun (and to Earth) in early 2023. The comet images in this interactive view were taken on different dates from December 2022 through January 2023 by astrophotographer <a href="http://www.astrostudio.at/" target="_blank" rel="noopener noreferrer">Gerald Rhemann</a>.
                 <br><br>
 
                 <h3>Explore!</h3>
@@ -394,7 +394,7 @@
                 <br><br><br>
                 <div class="credits">
                 <h3>Credits:</h3>
-                <h4><a href="https://www.cosmicds.cfa.harvard.edu/" target="_blank">CosmicDS</a> Mini Stories Team:</h4>
+                <h4><a href="https://www.cosmicds.cfa.harvard.edu/" target="_blank" rel="noopener noreferrer">CosmicDS</a> Mini Stories Team:</h4>
                 Jon Carifio<br>
                 John Lewis<br>
                 Pat Udomprasert<br>
@@ -502,7 +502,7 @@
                     <v-col cols="12">
                       <div class="credits">
                       <h3>Credits:</h3>
-                      <h4><a href="https://www.cosmicds.cfa.harvard.edu/" target="_blank">CosmicDS</a> Mini Stories Team:</h4>
+                      <h4><a href="https://www.cosmicds.cfa.harvard.edu/" target="_blank" rel="noopener noreferrer">CosmicDS</a> Mini Stories Team:</h4>
                       Jon Carifio<br>
                       John Lewis<br>
                       Pat Udomprasert<br>
@@ -1265,13 +1265,14 @@ export default defineComponent({
       const map = L.map("map-container").setView(locationDeg, 4);
       // L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
       //   maxZoom: 19,
-      //   attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+      //   attribution: '&copy; <a href="http://www.openstreetmap.org/copyright" target="_blank" rel="noopener noreferrer">OpenStreetMap</a>',
       //   className: 'map-tiles'
       // }).addTo(map);
+      map.attributionControl.setPrefix('<a href="https://leafletjs.com/" target="_blank" rel="noopener noreferrer">Leaflet</a>');
       L.tileLayer('https://{s}.google.com/vt/lyrs=p&x={x}&y={y}&z={z}',{
         maxZoom: 20,
         subdomains:['mt0','mt1','mt2','mt3'],
-        attribution: `&copy <a href="https://www.google.com/maps">Google Maps</a>`,
+        attribution: `&copy <a href="https://www.google.com/maps" target="_blank" rel="noopener noreferrer">Google Maps</a>`,
         className: 'map-tiles'
       }).addTo(map);
 

--- a/pinwheel-supernova/src/M101SN.vue
+++ b/pinwheel-supernova/src/M101SN.vue
@@ -52,7 +52,7 @@
         </div>
         
         <div id="splash-screen-acknowledgements">
-          This Mini Data Story is brought to you by <a href="https://www.cosmicds.cfa.harvard.edu/" target="_blank">Cosmic Data Stories</a> and <a href="https://www.worldwidetelescope.org/home/" target="_blank">WorldWide Telescope</a>.
+          This Mini Data Story is brought to you by <a href="https://www.cosmicds.cfa.harvard.edu/" target="_blank" rel="noopener noreferrer">Cosmic Data Stories</a> and <a href="https://www.worldwidetelescope.org/home/" target="_blank" rel="noopener noreferrer">WorldWide Telescope</a>.
           
           <div id="splash-screen-icons">
             <mini-credits/>
@@ -488,7 +488,7 @@
 
                 <p>
                   On May 19, 2023 - renowned supernova hunter 
-                  <a href="https://www.scientificamerican.com/article/astronomers-have-spotted-a-once-in-a-decade-supernova-and-you-can-too/" target="_blank">Koichi Itagaki discovered</a>
+                  <a href="https://www.scientificamerican.com/article/astronomers-have-spotted-a-once-in-a-decade-supernova-and-you-can-too/" target="_blank" rel="noopener noreferrer">Koichi Itagaki discovered</a>
                   a new bright object in the very nearby Pinwheel Galaxy (also known as M101). This bright object was a <strong>new supernova</strong>. 
                 </p>
                 <br/>
@@ -504,8 +504,8 @@
                   or a white dwarf (the remnants of stars like our Sun) pulls enough extra gas onto itself from a companion star that it blows up. 
                 </p>
                 <p>
-                  The first type of supernova is called a <a href="https://astronomy.swin.edu.au/cosmos/c/core-collapse">core-collapse supernova</a> (Type II) and can teach us about the evolution and environment of massive stars. 
-                  The second type (<a href="https://astronomy.swin.edu.au/cosmos/T/Type+Ia+Supernova">Type Ia</a>) have predictable brightness and are used to measure the cosmological expansion of the universe.
+                  The first type of supernova is called a <a href="https://astronomy.swin.edu.au/cosmos/c/core-collapse" target="_blank" rel="noopener noreferrer">core-collapse supernova</a> (Type II) and can teach us about the evolution and environment of massive stars. 
+                  The second type (<a href="https://astronomy.swin.edu.au/cosmos/T/Type+Ia+Supernova" target="_blank" rel="noopener noreferrer">Type Ia</a>) have predictable brightness and are used to measure the cosmological expansion of the universe.
                 </p>
                 
                 <h3>The Brightness Graph</h3>
@@ -516,7 +516,7 @@
                 </p>
                 <img src="./assets/sntyp.gif">
                 <p>
-                You can learn about other types of supernovae <a href="https://astrobites.org/2016/12/02/classifying-supernovae/">here</a>.
+                You can learn about other types of supernovae <a href="https://astrobites.org/2016/12/02/classifying-supernovae/" target="_blank" rel="noopener noreferrer">here</a>.
                 </p>
                 <strong>What type of supernova do you think the one in the Pinwheel Galaxy is?</strong>
                 <br>
@@ -540,15 +540,15 @@
                 <h3>Credits:</h3>
                 <h4> MicroObservatory:</h4>
                 <p>
-                  The images shown in the "Watch over time" sequence were taken with <a href="https://mo-www.cfa.harvard.edu/MicroObservatory/" target="_blank">MicroObservatory</a>. We use them here because they observe the Pinwheel Galaxy every night in a consistent way. (Dates without MicroObservatory images had bad weather). 
+                  The images shown in the "Watch over time" sequence were taken with <a href="https://mo-www.cfa.harvard.edu/MicroObservatory/" target="_blank" rel="noopener noreferrer">MicroObservatory</a>. We use them here because they observe the Pinwheel Galaxy every night in a consistent way. (Dates without MicroObservatory images had bad weather). 
                 </p>
 
                 <br/>
                 <h4> MicroObservatory Images and Data Processing:</h4>
-                <p>Martin Fowler (<a href="https://solarsystem.nasa.gov/people/647/martin-fowler/" target="_blank">NASA Citizen Scientist</a>)</p>
+                <p>Martin Fowler (<a href="https://solarsystem.nasa.gov/people/647/martin-fowler/" target="_blank" rel="noopener noreferrer">NASA Citizen Scientist</a>)</p>
                 <br/>
 
-                <h4><a href="https://www.cosmicds.cfa.harvard.edu/" target="_blank">CosmicDS</a> Mini Stories Team:</h4>
+                <h4><a href="https://www.cosmicds.cfa.harvard.edu/" target="_blank" rel="noopener noreferrer">CosmicDS</a> Mini Stories Team:</h4>
                 John Lewis<br>
                 Jon Carifio<br>
                 Pat Udomprasert<br>
@@ -645,7 +645,7 @@
                     <v-col cols="12">
                       <div class="credits">
                       <h3>Credits:</h3>
-                      <h4><a href="https://www.cosmicds.cfa.harvard.edu/" target="_blank">CosmicDS</a> Mini Stories Team:</h4>
+                      <h4><a href="https://www.cosmicds.cfa.harvard.edu/" target="_blank" rel="noopener noreferrer">CosmicDS</a> Mini Stories Team:</h4>
                       John Lewis<br>
                       Jon Carifio<br>
                       Pat Udomprasert<br>
@@ -1716,13 +1716,13 @@ export default defineComponent({
       const map = L.map("map-container").setView(locationDeg, 4);
       // L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
       //   maxZoom: 19,
-      //   attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+      //   attribution: '&copy; <a href="http://www.openstreetmap.org/copyright" target="_blank" rel="noopener noreferrer">OpenStreetMap</a>',
       //   className: 'map-tiles'
       // }).addTo(map);
       L.tileLayer('https://{s}.google.com/vt/lyrs=p&x={x}&y={y}&z={z}',{
         maxZoom: 20,
         subdomains:['mt0','mt1','mt2','mt3'],
-        attribution: `&copy <a href="https://www.google.com/maps">Google Maps</a>`,
+        attribution: `&copy <a href="https://www.google.com/maps" target="_blank" rel="noopener noreferrer">Google Maps</a>`,
         className: 'map-tiles'
       }).addTo(map);
 


### PR DESCRIPTION
for all existing stories using `target="_blank"`, and add `rel="noopener noreferrer"` to avoid malicious attacks from pages we link to.

I found some opinionated chatter online about how it's not a best practice to force pages to open in new windows, but from what I could gather, people are less cranky about that now that all browsers use tabs. Anyway, I think our use case warrants it because if a user were to click a link and have to hit "back" to return to the minids, it would be completely reset, which would be annoying if a user was setting up a particular view in the sky.