### PR TITLE
Hook up time controls

### DIFF
--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -1473,11 +1473,4 @@ video {
   }
 }
 
-
-table.show-time tr>td:first-child {
-  font-weight: bold;
-  padding-right: 1em;
-}
-
-
 </style>

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -1059,6 +1059,12 @@ export default defineComponent({
       this.timeOfDay = hms;
     },
 
+    wwtCurrentTime(time: Date) {
+      if (this.syncDateTimeWithWWTCurrentTime) {
+        this.selectedTime = time.getTime();
+      }
+    },
+
     selectedTimezone(newTz: string, oldTz: string) {
       const newOffset = getTimezoneOffset(newTz);
       const oldOffset = getTimezoneOffset(oldTz);

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -614,6 +614,8 @@ export default defineComponent({
       LayerManager._draw = layerManagerDraw;      
 
       this.updateWWTLocation();
+      this.setClockSync(true);
+      this.setClockRate(1);
 
       this.gotoRADecZoom({
         // These are RA/Dec of Sun in Albuquerque close to max annularity. Since I don't know how to keep focus on the Sun in the web engine, I tried to set this up so the view would start here, but it isn't.

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -637,6 +637,8 @@ export default defineComponent({
       console.log("selected time", this.selectedTime);
 
     });
+
+    this.timeOfDay = { ...this.timeOfDay }; // force times to sync after everything is mounted
   },
 
   computed: {

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -480,14 +480,14 @@ export default defineComponent({
     },
   },
   data() {
-    const totalEclipseTimeNMTZ = new Date("2023-10-14T10:48");
-    const _totalEclipseTimeUTC = new Date("2023-10-14T16:48:00Z");
+    const annularEclipseTimeNMTZ = new Date("2023-10-14T10:48");
+    const _annularEclipseTimeUTC = new Date("2023-10-14T16:48:00Z");
     console.log("min/max time UTC", minTime, maxTime);
     const minutc = new Date(minTime);
     const maxutc = new Date(maxTime);
     console.log("Date(min/maxTime):", minutc, maxutc);
     console.log("min max date", minutc.toUTCString(), maxutc.toUTCString());
-    console.log("date:", totalEclipseTimeNMTZ);
+    console.log("date:", annularEclipseTimeNMTZ);
     return {
       showSplashScreen: false,
       backgroundImagesets: [] as BackgroundImageset[],
@@ -507,8 +507,8 @@ export default defineComponent({
       pointerStartPosition: null as { x: number; y: number } | null,      
 
       // Albuquerque, NM
-      timeOfDay: { hours: totalEclipseTimeNMTZ.getHours(), minutes: totalEclipseTimeNMTZ.getMinutes(), seconds: totalEclipseTimeNMTZ.getSeconds() },
-      selectedTime: _totalEclipseTimeUTC.getTime(), //1697302060000,
+      timeOfDay: { hours: annularEclipseTimeNMTZ.getHours(), minutes: annularEclipseTimeNMTZ.getMinutes(), seconds: annularEclipseTimeNMTZ.getSeconds() },
+      selectedTime: _annularEclipseTimeUTC.getTime(), //1697302060000,
       selectedTimezone: "America/Denver",
       location: {
         latitudeRad: D2R * 35.106766,

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -1033,6 +1033,14 @@ export default defineComponent({
       this.updateHorizon();
     },
     timeOfDay(_time: { hours: number; minutes: number; seconds: number }) {
+      const date = this.selectedDate;
+      const offset = this.selectedTimezoneOffset / (1000*60*60);
+      date.setUTCHours(this.timeOfDay.hours - offset, this.timeOfDay.minutes, this.timeOfDay.seconds);
+      this.selectedTime = date.getTime();
+    },
+    
+    dateTime(_date: Date) {
+      console.log('watch dateTime');
       this.updateForDateTime();
     },
 

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -640,6 +640,9 @@ export default defineComponent({
 
     dateTime() {
       const todMs = this.dayFrac * MILLISECONDS_PER_DAY;
+      let time = this.selectedDate.getTime();
+      time -= time % MILLISECONDS_PER_DAY;
+      return new Date(time + todMs);
     },    
 
     selectedTimezoneOffset() {

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -156,13 +156,13 @@
               label="Horizon"
               hide-details
             />
-            <div
+            <!-- <div
               style="color:white;"
               class="mt-3"
             >
               Selected location's time:
-            </div>
-            <date-picker
+            </div> -->
+            <!-- <date-picker
               dark
               time-picker
               enable-seconds
@@ -179,7 +179,7 @@
                   :color="accentColor"
                 ></font-awesome-icon>
               </template>
-            </date-picker>
+            </date-picker> -->
             <!-- <v-btn
               block
               :color="accentColor"
@@ -505,6 +505,7 @@ export default defineComponent({
   },
   data() {
     const totalEclipseTimeNMTZ = new Date("2023-10-14T10:48");
+    const _totalEclipseTimeUTC = new Date("2023-10-14T16:48:00Z");
     console.log("min/max time UTC", minTime, maxTime);
     const minutc = new Date(minTime);
     const maxutc = new Date(maxTime);
@@ -531,7 +532,7 @@ export default defineComponent({
 
       // Albuquerque, NM
       timeOfDay: { hours: totalEclipseTimeNMTZ.getHours(), minutes: totalEclipseTimeNMTZ.getMinutes(), seconds: totalEclipseTimeNMTZ.getSeconds() },
-      selectedTime: minTime,
+      selectedTime: _totalEclipseTimeUTC.getTime(), //1697302060000,
       selectedTimezone: "America/Denver",
       location: {
         latitudeRad: D2R * 35.106766,
@@ -640,18 +641,25 @@ export default defineComponent({
 
     });
 
-    this.timeOfDay = { ...this.timeOfDay }; // force times to sync after everything is mounted
+    // this.timeOfDay = { ...this.timeOfDay }; // force times to sync after everything is mounted
+    // force times to sync after everything is mounted
+    // setInterval(() => {
+    //   console.log("sync clocks");
+    //   console.log(this.selectedTime);
+    //   console.log(this.wwtCurrentTime.getTime());
+    //   // this.selectedTime = this.wwtCurrentTime.getTime();
+    // }, 1000);
   },
 
   computed: {
 
     dateTime() {
-      const hours = this.timeOfDay.hours - this.selectedTimezoneOffset / (1000 * 60 * 60);
-      const minutes = this.timeOfDay.minutes;
-      const seconds = this.timeOfDay.seconds;
-      const time = this.selectedDate;
-      time.setUTCHours(hours, minutes, seconds);
-      return new Date(time);
+      // const hours = this.timeOfDay.hours - this.selectedTimezoneOffset / (1000 * 60 * 60);
+      // const minutes = this.timeOfDay.minutes;
+      // const seconds = this.timeOfDay.seconds;
+      // const time = this.selectedDate;
+      // time.setUTCHours(hours, minutes, seconds);
+      return new Date(this.selectedTime);
     },    
 
     selectedTimezoneOffset() {
@@ -1036,12 +1044,12 @@ export default defineComponent({
     showHorizon(_show: boolean) {
       this.updateHorizon();
     },
-    timeOfDay(_time: { hours: number; minutes: number; seconds: number }) {
-      const date = this.selectedDate;
-      const offset = this.selectedTimezoneOffset / (1000*60*60);
-      date.setUTCHours(this.timeOfDay.hours - offset, this.timeOfDay.minutes, this.timeOfDay.seconds);
-      this.selectedTime = date.getTime();
-    },
+    // timeOfDay(_time: { hours: number; minutes: number; seconds: number }) {
+    //   const date = this.selectedDate;
+    //   const offset = this.selectedTimezoneOffset / (1000*60*60);
+    //   date.setUTCHours(this.timeOfDay.hours - offset, this.timeOfDay.minutes, this.timeOfDay.seconds);
+    //   this.selectedTime = date.getTime();
+    // },
     
     dateTime(_date: Date) {
       console.log('watch dateTime');
@@ -1049,20 +1057,19 @@ export default defineComponent({
     },
 
     selectedTime(_time: number) {
-      const date = new Date(this.selectedTime);
-      const hms = {
-        // need the local time here, not UTC, so add the offset
-        hours: date.getUTCHours() + this.selectedTimezoneOffset / (1000*60*60),
-        minutes: date.getUTCMinutes(),
-        seconds: date.getUTCSeconds()
-      };
-      this.timeOfDay = hms;
+      return;
+      // const date = new Date(this.selectedTime);
+      // const hms = {
+      //   // need the local time here, not UTC, so add the offset
+      //   hours: date.getUTCHours() + this.selectedTimezoneOffset / (1000*60*60),
+      //   minutes: date.getUTCMinutes(),
+      //   seconds: date.getUTCSeconds()
+      // };
+      // this.timeOfDay = hms;
     },
 
-    wwtCurrentTime(time: Date) {
-      if (this.syncDateTimeWithWWTCurrentTime) {
-        this.selectedTime = time.getTime();
-      }
+    wwtCurrentTime(_time: Date) {
+      // this.selectedTime = _time.getTime();
     },
 
     selectedTimezone(newTz: string, oldTz: string) {

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -538,6 +538,9 @@ export default defineComponent({
         longitudeRad: D2R * -106.629181
       } as LocationRad,
       locationErrorMessage: "",
+      
+      syncDateTimeWithWWTCurrentTime: true,
+      syncDateTimewithSelectedTime: true,
 
       playing: false,
       playingIntervalId: null as ReturnType<typeof setInterval> | null,
@@ -992,7 +995,7 @@ export default defineComponent({
 
 
     updateForDateTime() {
-      // if (!this.dontSetTime) { this.setTime(this.dateTime); }
+      this.syncDateTimeWithWWTCurrentTime ? this.setTime(this.dateTime) : null;
       this.updateHorizon(this.dateTime); 
       // this.showImageForDateTime(this.dateTime);
       // this.updateViewForDate(options);

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -614,8 +614,8 @@ export default defineComponent({
       LayerManager._draw = layerManagerDraw;      
 
       this.updateWWTLocation();
-      this.setClockSync(true);
-      this.setClockRate(1);
+      this.setClockSync(false); // set to false to pause
+      this.setClockRate(1); //
 
       this.gotoRADecZoom({
         // These are RA/Dec of Sun in Albuquerque close to max annularity. Since I don't know how to keep focus on the Sun in the web engine, I tried to set this up so the view would start here, but it isn't.

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -591,7 +591,7 @@ export default defineComponent({
       LayerManager._draw = layerManagerDraw;      
 
       this.updateWWTLocation();
-      this.setClockSync(true); // set to false to pause
+      this.setClockSync(false); // set to false to pause
       this.setClockRate(1); //
 
       this.gotoRADecZoom({

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -513,7 +513,7 @@ export default defineComponent({
     console.log("min max date", minutc.toUTCString(), maxutc.toUTCString());
     console.log("date:", totalEclipseTimeNMTZ);
     return {
-      showSplashScreen: true,
+      showSplashScreen: false,
       backgroundImagesets: [] as BackgroundImageset[],
       sheet: null as SheetType,
       layersLoaded: false,
@@ -615,7 +615,7 @@ export default defineComponent({
       LayerManager._draw = layerManagerDraw;      
 
       this.updateWWTLocation();
-      this.setClockSync(false); // set to false to pause
+      this.setClockSync(true); // set to false to pause
       this.setClockRate(1); //
 
       this.gotoRADecZoom({
@@ -1070,6 +1070,7 @@ export default defineComponent({
 
     wwtCurrentTime(_time: Date) {
       // this.selectedTime = _time.getTime();
+      this.updateHorizon(_time);
     },
 
     selectedTimezone(newTz: string, oldTz: string) {

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -642,10 +642,12 @@ export default defineComponent({
   computed: {
 
     dateTime() {
-      const todMs = this.dayFrac * MILLISECONDS_PER_DAY;
-      let time = this.selectedDate.getTime();
-      time -= time % MILLISECONDS_PER_DAY;
-      return new Date(time + todMs);
+      const hours = this.timeOfDay.hours - this.selectedTimezoneOffset / (1000 * 60 * 60);
+      const minutes = this.timeOfDay.minutes;
+      const seconds = this.timeOfDay.seconds;
+      const time = this.selectedDate;
+      time.setUTCHours(hours, minutes, seconds);
+      return new Date(time);
     },    
 
     selectedTimezoneOffset() {

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -156,30 +156,6 @@
               label="Horizon"
               hide-details
             />
-            <!-- <div
-              style="color:white;"
-              class="mt-3"
-            >
-              Selected location's time:
-            </div> -->
-            <!-- <date-picker
-              dark
-              time-picker
-              enable-seconds
-              :is-24="false"
-              v-model="timeOfDay"
-              :clearable="false"
-              close-on-scroll
-              class="mb-4 mt-1"
-            >
-              <template #input-icon>
-                <font-awesome-icon
-                  icon="clock"
-                  class="mx-2"
-                  :color="accentColor"
-                ></font-awesome-icon>
-              </template>
-            </date-picker> -->
             <!-- <v-btn
               block
               :color="accentColor"
@@ -641,24 +617,11 @@ export default defineComponent({
 
     });
 
-    // this.timeOfDay = { ...this.timeOfDay }; // force times to sync after everything is mounted
-    // force times to sync after everything is mounted
-    // setInterval(() => {
-    //   console.log("sync clocks");
-    //   console.log(this.selectedTime);
-    //   console.log(this.wwtCurrentTime.getTime());
-    //   // this.selectedTime = this.wwtCurrentTime.getTime();
-    // }, 1000);
   },
 
   computed: {
 
     dateTime() {
-      // const hours = this.timeOfDay.hours - this.selectedTimezoneOffset / (1000 * 60 * 60);
-      // const minutes = this.timeOfDay.minutes;
-      // const seconds = this.timeOfDay.seconds;
-      // const time = this.selectedDate;
-      // time.setUTCHours(hours, minutes, seconds);
       return new Date(this.selectedTime);
     },    
 
@@ -1044,12 +1007,7 @@ export default defineComponent({
     showHorizon(_show: boolean) {
       this.updateHorizon();
     },
-    // timeOfDay(_time: { hours: number; minutes: number; seconds: number }) {
-    //   const date = this.selectedDate;
-    //   const offset = this.selectedTimezoneOffset / (1000*60*60);
-    //   date.setUTCHours(this.timeOfDay.hours - offset, this.timeOfDay.minutes, this.timeOfDay.seconds);
-    //   this.selectedTime = date.getTime();
-    // },
+
     
     dateTime(_date: Date) {
       console.log('watch dateTime');
@@ -1058,14 +1016,6 @@ export default defineComponent({
 
     selectedTime(_time: number) {
       return;
-      // const date = new Date(this.selectedTime);
-      // const hms = {
-      //   // need the local time here, not UTC, so add the offset
-      //   hours: date.getUTCHours() + this.selectedTimezoneOffset / (1000*60*60),
-      //   minutes: date.getUTCMinutes(),
-      //   seconds: date.getUTCSeconds()
-      // };
-      // this.timeOfDay = hms;
     },
 
     wwtCurrentTime(_time: Date) {

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -75,7 +75,7 @@
       <div id="right-buttons">
       </div>
     </div>
-    
+
 
     <div class="bottom-content">
       <div
@@ -452,7 +452,7 @@ export default defineComponent({
     sunPlace.set_zoomLevel(20);
 
     return {
-      showSplashScreen: false,
+      showSplashScreen: true,
       backgroundImagesets: [] as BackgroundImageset[],
       sheet: null as SheetType,
       layersLoaded: false,
@@ -551,7 +551,6 @@ export default defineComponent({
       console.log("selected time", this.selectedTime);
 
     });
-
   },
 
   computed: {

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -68,7 +68,47 @@
       <div id="right-buttons">
       </div>
     </div>
-
+    
+    <div id="track-time">
+        <table class="show-time">
+          <tr>
+            <td class="ui-text"> selectedTimezone: </td>
+            <td class="ui-text"> {{ selectedTimezone }} </td>
+          </tr>
+          <tr>
+            <td class="ui-text"> selectedTimezoneOffset: </td>
+            <td class="ui-text"> {{ selectedTimezoneOffset / (1000 * 60 * 60) }} hr </td>
+          </tr>
+          <tr>
+            <td class="ui-text"> selectedTime (raw): </td>
+            <td class="ui-text"> {{ selectedTime }} </td>
+          </tr>
+          <tr>
+            <td class="ui-text"> selectedTime: </td>
+            <td class="ui-text"> {{ new Date(selectedTime).toUTCString() }} </td>
+          </tr>
+          <tr>
+            <td class="ui-text"> selectedDate: </td>
+            <td class="ui-text"> {{ selectedDate.toUTCString() }} </td>
+          </tr>
+          <tr>
+            <td class="ui-text"> wwtCurrentTime: </td>
+            <td class="ui-text"> {{ wwtCurrentTime.toUTCString() }} </td>
+          </tr>
+          <tr>
+            <td class="ui-text"> timeOfDay (from date-picker): </td>
+            <td class="ui-text"> {{ timeOfDay }} </td>
+          </tr>
+          <tr>
+            <td class="ui-text"> dayFrac: </td>
+            <td class="ui-text"> {{ dayFrac  }} </td>
+          </tr>
+          <tr>
+            <td class="ui-text"> dateTime: </td>
+            <td class="ui-text"> {{ dateTime.toUTCString() }} </td>
+          </tr>
+        </table>
+      </div>
 
     <div class="bottom-content">
       <div
@@ -1474,5 +1514,20 @@ video {
     cursor: grabbing;
   }
 }
+
+#track-time {
+  position: absolute;
+  top: 15%;
+  margin: 0 30px;
+  color: white;
+  font-size: 0.8em;
+  
+}
+
+table.show-time tr>td:first-child {
+  font-weight: bold;
+  padding-right: 1em;
+}
+
 
 </style>

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -504,13 +504,13 @@ export default defineComponent({
     },
   },
   data() {
-    const now = new Date("2023-10-14T10:48");
+    const totalEclipseTimeNMTZ = new Date("2023-10-14T10:48");
     console.log("min/max time UTC", minTime, maxTime);
     const minutc = new Date(minTime);
     const maxutc = new Date(maxTime);
     console.log("Date(min/maxTime):", minutc, maxutc);
     console.log("min max date", minutc.toUTCString(), maxutc.toUTCString());
-    console.log("date:", now);
+    console.log("date:", totalEclipseTimeNMTZ);
     return {
       showSplashScreen: true,
       backgroundImagesets: [] as BackgroundImageset[],
@@ -530,7 +530,7 @@ export default defineComponent({
       pointerStartPosition: null as { x: number; y: number } | null,      
 
       // Albuquerque, NM
-      timeOfDay: { hours: now.getHours(), minutes: now.getMinutes(), seconds: now.getSeconds() },
+      timeOfDay: { hours: totalEclipseTimeNMTZ.getHours(), minutes: totalEclipseTimeNMTZ.getMinutes(), seconds: totalEclipseTimeNMTZ.getSeconds() },
       selectedTime: minTime,
       selectedTimezone: "America/Denver",
       location: {

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -437,6 +437,9 @@ const R2D = 180 / Math.PI;
 const minTime = Date.UTC(2023, 9, 14, 15, 0); // eclipse starts at 9:13am MT in Albuquerque
 const maxTime = Date.UTC(2023, 9, 14, 18, 30); // eclipse ends at 12:09pm MT in Albuquerque
 
+const SECONDS_PER_DAY = 60 * 60 * 24;
+const MILLISECONDS_PER_DAY = 1000 * SECONDS_PER_DAY;
+
 const secondsInterval = 10;
 const MILLISECONDS_PER_INTERVAL = 1000 * secondsInterval;
 
@@ -636,9 +639,7 @@ export default defineComponent({
   computed: {
 
     dateTime() {
-      return new Date();
-      // const todMs = this.dayFrac * MILLISECONDS_PER_INTERVAL;
-      // return new Date(this.selectedDate.getTime() + todMs);
+      const todMs = this.dayFrac * MILLISECONDS_PER_DAY;
     },    
 
     selectedTimezoneOffset() {
@@ -676,14 +677,14 @@ export default defineComponent({
       return Settings.get_active();
     },
     // dontSetTime(): boolean {
-    //   return this.selectedTime %MILLISECONDS_PER_INTERVAL !== 0;
+    //   return this.selectedTime %MILLISECONDS_PER_DAY !== 0;
     // },
     dayFrac(): number {
       const dateForTOD = new Date();
       const timezoneOffsetHours = this.selectedTimezoneOffset / (60*60*1000);
       dateForTOD.setUTCHours(this.timeOfDay.hours - timezoneOffsetHours, this.timeOfDay.minutes, this.timeOfDay.seconds);
       const todMs = 1000 * (3600 * dateForTOD.getUTCHours() + 60 * dateForTOD.getUTCMinutes() + dateForTOD.getUTCSeconds());
-      return todMs / MILLISECONDS_PER_INTERVAL;
+      return todMs / MILLISECONDS_PER_DAY;
     },
     showTextSheet: {
       get(): boolean {

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -1035,9 +1035,18 @@ export default defineComponent({
     timeOfDay(_time: { hours: number; minutes: number; seconds: number }) {
       this.updateForDateTime();
     },
-    // selectedDate() {
-    //   this.updateForDateTime();
-    // },
+
+    selectedTime(_time: number) {
+      const date = new Date(this.selectedTime);
+      const hms = {
+        // need the local time here, not UTC, so add the offset
+        hours: date.getUTCHours() + this.selectedTimezoneOffset / (1000*60*60),
+        minutes: date.getUTCMinutes(),
+        seconds: date.getUTCSeconds()
+      };
+      this.timeOfDay = hms;
+    },
+
     selectedTimezone(newTz: string, oldTz: string) {
       const newOffset = getTimezoneOffset(newTz);
       const oldOffset = getTimezoneOffset(oldTz);

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -729,14 +729,30 @@ export default defineComponent({
       this.selectedTime -= MILLISECONDS_PER_INTERVAL;
     },
 
-    toDateString(date: Date) {
+    toUTCDateString(date: Date) {
       // date = new Date(date.getTime() + this.selectedTimezoneOffset) // ignore timezone
       return `${date.getUTCMonth() + 1}/${date.getUTCDate()}/${date.getUTCFullYear()}`;
     },
 
+    toUTCTimeString(date: Date) {
+      const minutes = date.getUTCMinutes();
+      const minuteString = minutes < 10 ? `0${minutes}` : `${minutes}`;
+      // get am pm
+      const ampm = date.getUTCHours() < 12 ? "AM" : "PM";
+      return `${date.getUTCHours()}:${minuteString} ${ampm}`;
+    },
+
+    toLocaleTimeString(date: Date) {
+      date = new Date(date.getTime() + this.selectedTimezoneOffset);
+      const minutes = date.getUTCMinutes();
+      const minuteString = minutes < 10 ? `0${minutes}` : `${minutes}`;
+      // get am pm
+      const ampm = date.getUTCHours() < 12 ? "AM" : "PM";
+      return `${date.getUTCHours()}:${minuteString} ${ampm}`;
+    },
+
     toTimeString(date: Date) {
-      date = new Date(date.getTime() + this.selectedTimezoneOffset); // ignore timezone
-      return `${date.getUTCHours()}:${date.getUTCMinutes()}`;
+      return this.toLocaleTimeString(date);
     },
 
     closeSplashScreen() {

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -76,46 +76,6 @@
       </div>
     </div>
     
-    <div id="track-time">
-        <table class="show-time">
-          <tr>
-            <td class="ui-text"> selectedTimezone: </td>
-            <td class="ui-text"> {{ selectedTimezone }} </td>
-          </tr>
-          <tr>
-            <td class="ui-text"> selectedTimezoneOffset: </td>
-            <td class="ui-text"> {{ selectedTimezoneOffset / (1000 * 60 * 60) }} hr </td>
-          </tr>
-          <tr>
-            <td class="ui-text"> selectedTime (raw): </td>
-            <td class="ui-text"> {{ selectedTime }} </td>
-          </tr>
-          <tr>
-            <td class="ui-text"> selectedTime: </td>
-            <td class="ui-text"> {{ new Date(selectedTime).toUTCString() }} </td>
-          </tr>
-          <tr>
-            <td class="ui-text"> selectedDate: </td>
-            <td class="ui-text"> {{ selectedDate.toUTCString() }} </td>
-          </tr>
-          <tr>
-            <td class="ui-text"> wwtCurrentTime: </td>
-            <td class="ui-text"> {{ wwtCurrentTime.toUTCString() }} </td>
-          </tr>
-          <tr>
-            <td class="ui-text"> timeOfDay (from date-picker): </td>
-            <td class="ui-text"> {{ timeOfDay }} </td>
-          </tr>
-          <tr>
-            <td class="ui-text"> dayFrac: </td>
-            <td class="ui-text"> {{ dayFrac  }} </td>
-          </tr>
-          <tr>
-            <td class="ui-text"> dateTime: </td>
-            <td class="ui-text"> {{ dateTime.toUTCString() }} </td>
-          </tr>
-        </table>
-      </div>
 
     <div class="bottom-content">
       <div
@@ -1514,14 +1474,6 @@ video {
   }
 }
 
-#track-time {
-  position: absolute;
-  top: 15%;
-  margin: 0 30px;
-  color: white;
-  font-size: 0.8em;
-  
-}
 
 table.show-time tr>td:first-child {
   font-weight: bold;


### PR DESCRIPTION
This hooks up the time controls resolving #158  and builds on #156

Here is a little diagram of how the times are connected. It follows the same basic structure as in the green-comet, but a little simplified with a couple changes so that how things are related is clearer. The main change is that in the green-comet we don't set `wwtCurrentTime` and `dateTime` uses `dayFrac` to get the time. 

These two diagrams show what calls what to update the different times. The watchers for `timeOfDay` and `selectedTime` keep each other in sync. `timeOfDay` sets hours in local time. The `time-picker` sets time in UTC (but is displayed on the slider in local time using `toTimeString` which wraps a new `toLocaleTimeString`). 

There is a variable `syncDateTimeWithWWTCurrentTime` which can be set to False break syncing between the user set time and WorldWideTelescopes clock
  
**Using the `time slider`**
    
     
```mermaid
graph TD
    subgraph "WWT UTC Time"
        W(wwtCurrentTime)
    end 
    subgraph Settings
        sT[selectedTime]
        tD[timeOfDay]
        sTZ[selectedTimezone]
    end
    
    subgraph Functions
        ufDT[updateForDateTime]
        Date["new Date()"]
        gTZo["getTimeZoneOffset()"]
        setTime["setTime(dateTime)"]
    end
    
    subgraph Computed
        sTZo[selectedTimezoneOffset]
        sD[selectedDate]
        dT[dateTime]
        dF[dayFrac]
    end
    
    subgraph "Time Slider"
        sTZ --> gTZo --> sTZo --> dT
        sT --> Date --> sD --> dT
        dT --> ufDT --> setTime --> W
    end
```

**Using the `date-picker`**
    
```mermaid
graph TD
    subgraph "WWT UTC Time"
        W(wwtCurrentTime)
    end 
    subgraph Settings
        sT[selectedTime]
        tD[timeOfDay]
        sTZ[selectedTimezone]
    end
    
    subgraph Functions
        ufDT[updateForDateTime]
        Date["new Date()"]
        gTZo["getTimeZoneOffset()"]
        setTime["setTime(dateTime)"]
    end
    
    subgraph Computed
        sTZo[selectedTimezoneOffset]
        sD[selectedDate]
        dT[dateTime]
        dF[dayFrac]
    end


    subgraph "Date Picker"
        tD --> dT
        sTZ --> gTZo --> sTZo --> dT
        dT --> ufDT --> setTime --> W
    end
```

**Keeping things in sync**
    
```mermaid
graph LR
    subgraph "WWT UTC Time"
        W(wwtCurrentTime)
    end 
    subgraph Settings
        sT[selectedTime] --> dT
        tD[timeOfDay] --> dT

    end

    subgraph Computed
        dT(dateTime) --> wdT
    end

    subgraph Functions
        ufDT[updateForDateTime]
        setTime["setTime(dateTime)"]
    end

    subgraph Watchers
        wsT[watch: selectedTime]
        wsT -- "updates (UTC to local)" --> tD
        wTd[watch: timeOfDay]
        wTd -- "updates (local to UTC)" --> sT
        wdT[watch: dateTime]
        wdT -- runs --> ufDT --> setTime --> W
    end
```
