### PR TITLE
Sun tracking for eclipse mini

### DIFF
--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -366,11 +366,10 @@
 
 <script lang="ts">
 import { defineComponent, PropType } from "vue";
-// import { distance } from "@wwtelescope/astro";
 import { MiniDSBase, BackgroundImageset, skyBackgroundImagesets } from "@minids/common";
+import { GotoTargetOptions } from "@wwtelescope/engine-helpers";
 import { GotoRADecZoomParams } from "@wwtelescope/engine-pinia";
-// import { GotoTargetOptions } from "@wwtelescope/engine-helpers";
-// import { Color, Constellations, Folder, Grids, Layer, LayerManager, Poly, RenderContext, Settings, SpreadSheetLayer, WWTControl, GetName } from "@wwtelescope/engine";
+import { Classification, SolarSystemObjects } from "@wwtelescope/engine-types";
 import { Constellations, Folder, Grids, LayerManager, Poly,Settings, WWTControl, Place  } from "@wwtelescope/engine";
 
 import { getTimezoneOffset } from "date-fns-tz";
@@ -515,37 +514,14 @@ export default defineComponent({
 
   mounted() {
     this.waitForReady().then(async () => {
-      
-      this.backgroundImagesets = [...skyBackgroundImagesets];
 
-      // this.imagesetFolder = await this.loadImageCollection({
-      //   url: this.wtml.eclipse,
-      //   loadChildFolders: false
-      // });
-      // const children = this.imagesetFolder.get_children() ?? [];
-      // const layerPromises: Promise<Layer>[] = [];
-      // children.forEach((item) => {
-      //   if (!(item instanceof Place)) { return; }
-      //   const imageset = item.get_backgroundImageset() ?? item.get_studyImageset();
-      //   if (imageset == null) { return; }
-      //   const name = imageset.get_name();
-      //   layerPromises.push(this.addImageSetLayer({
-      //     url: imageset.get_url(),
-      //     mode: "autodetect",
-      //     name: name,
-      //     goto: false
-      //   }).then((layer) => {
-      //     // this.imagesetLayers[name] = layer;
-      //     // applyImageSetLayerSetting(layer, ["opacity", 0]);
-      //     return layer;
-      //   }));
-      // });  
+      this.backgroundImagesets = [...skyBackgroundImagesets];
 
       console.log("initial camera params RA, Dec:", R2D * this.initialCameraParams.raRad/15, R2D * this.initialCameraParams.decRad);
 
       this.setTime(this.dateTime);
 
-      this.wwtSettings.set_localHorizonMode(true);
+      //this.wwtSettings.set_localHorizonMode(true);
       this.wwtSettings.set_showAltAzGrid(this.showAltAzGrid);
       this.wwtSettings.set_showAltAzGridText(this.showAltAzGrid);
       this.wwtSettings.set_showConstellationLabels(this.showConstellations);
@@ -569,21 +545,25 @@ export default defineComponent({
 
       this.updateWWTLocation();
 
-      this.gotoRADecZoom({
-        // These are RA/Dec of Sun in Albuquerque close to max annularity. Since I don't know how to keep focus on the Sun in the web engine, I tried to set this up so the view would start here, but it isn't.
-        raRad: 3.481,
-        decRad: -0.145,
-        zoomDeg: 1,
-        instant: true
-      }).then(() => this.positionSet = true);
+      setTimeout(() => {
+        const sunPlace = new Place();
+        sunPlace.set_names(["Sun"]);
+        sunPlace.set_classification(Classification.solarSystem);   
+        sunPlace.set_target(SolarSystemObjects.sun);
+        sunPlace.set_zoomLevel(10);
+        this.wwtControl.renderContext.set_solarSystemTrack(0);
+        const options: GotoTargetOptions = {
+          place: sunPlace,
+          instant: true,
+          noZoom: false,
+          trackObject: true 
+        };
+        this.gotoTarget(options).then(() => this.positionSet = true);
 
-      // this.gotoTarget({
-      //   place: this.sunPlace,
-      //   noZoom: true,
-      //   instant: true,
-      //   trackObject: true
-      // });
-      // console.log(this.sunPlace);
+        this.setClockRate(100);
+        console.log(this);
+        console.log(sunPlace);
+      }, 100);
 
       // If there are layers to set up, do that here!
       this.layersLoaded = true;

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -63,7 +63,14 @@
           :activator-color="accentColor"
         >
         </location-selector>    
-    
+        <icon-button
+          fa-icon="sun"
+          :color="accentColor"
+          tooltip-text="Center view on Sun"
+          tooltip-location='top'
+          @activate="() => trackSun()"
+        >
+        </icon-button>
       </div>
       <div id="right-buttons">
       </div>
@@ -462,7 +469,7 @@ export default defineComponent({
     sunPlace.set_names(["Sun"]);
     sunPlace.set_classification(Classification.solarSystem);   
     sunPlace.set_target(SolarSystemObjects.sun);
-    sunPlace.set_zoomLevel(10);
+    sunPlace.set_zoomLevel(20);
 
     return {
       showSplashScreen: true,
@@ -551,9 +558,6 @@ export default defineComponent({
 
       setTimeout(() => {
         this.trackSun().then(() => this.positionSet = true);
-
-        console.log(this);
-        console.log(this.sunPlace);
       }, 100);
 
       // If there are layers to set up, do that here!
@@ -1149,6 +1153,11 @@ body {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
+
+  #center-buttons {
+    display: flex;
+    flex-direction: row;
+  }
 }
 
 .bottom-content {

--- a/annular-eclipse-2023/src/main.ts
+++ b/annular-eclipse-2023/src/main.ts
@@ -29,6 +29,7 @@ import {
   faClock,
   faPlay,
   faPause,
+  faSun
 } from "@fortawesome/free-solid-svg-icons";
 
 library.add(faBookOpen);
@@ -39,6 +40,7 @@ library.add(faChevronDown);
 library.add(faClock);
 library.add(faPlay);
 library.add(faPause);
+library.add(faSun);
 
 /** v-hide directive taken from https://www.ryansouthgate.com/2020/01/30/vue-js-v-hide-element-whilst-keeping-occupied-space/ */
 // Extract the function out, up here, so I'm not writing it twice


### PR DESCRIPTION
This PR aims to resolve #159. To do this, the view is initially set to track the sun by default. This means that as time runs forward, the camera will stay focused on the Sun's current location. In WWT, the currently tracked object is "untracked" if the user moves the view. To allow the user to re-track the sun, I've added an icon button that will do that if pressed.