### PR TITLE
Fix issue with Green Comet test

### DIFF
--- a/tests/green-comet/basic.ts
+++ b/tests/green-comet/basic.ts
@@ -83,6 +83,8 @@ const tests: GreenCometTests = {
       "@selectedLocationTimeLabel", "@selectedLocationTimeInput",
       "@timeIcon", "@centerOnNowButton", "@playCometImagesButton"
     ]);
+
+    controls.click("@openCloseButton");
   },
 
   'Open video': function() {
@@ -165,7 +167,6 @@ const tests: GreenCometTests = {
   'Control Panel': function() {
     const controls = this.sections.controls;
 
-    controls.click("@openCloseButton");
     controls.expect.element("@openCloseButton").to.have.attribute("data-icon", "gear");
     expectAllNotPresent(controls, [
       "@gridInput", "@constellationsInput", "@horizonInput",


### PR DESCRIPTION
I think the reason that the Green Comet test is flaky on the BrowserStack Safari is because the controls can block the video icon on smaller screens. For whatever reason, BrowserStack likes to open Safari in particular on a smaller screen. This will hopefully resolve the issue - this updates the test sequence to close the controls before the video icon is pressed.