### PR TITLE
Add location dropdown

### DIFF
--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -81,9 +81,8 @@
           </template>
             <div id="eclipse-location-selector">
               <v-select
-                :items="eclipsePathLocations"
-                item-title="name"
-                :return-object="true"
+                :model-value="selectedLocation"
+                :items="Object.keys(eclipsePathLocations)"
                 label="Select eclipse viewing location"
                 :color="accentColor"
                 @update:model-value="updateLocation"
@@ -441,6 +440,11 @@ type LocationRad = {
   latitudeRad: number;
 };
 
+interface EclipseLocation extends LocationRad {
+  name: string;
+  eclipseFracion: number | null;
+}
+
 type EquatorialRad = {
   raRad: number;
   decRad: number;
@@ -520,65 +524,71 @@ export default defineComponent({
         latitudeRad: D2R * 35.106766,
         longitudeRad: D2R * -106.629181
       } as LocationRad,
+      selectedLocation: "Albuquerque, NM",
       locationErrorMessage: "",
 
-      eclipsePathLocations: [
-        {
+      eclipsePathLocations: {
+        "Albuquerque, NM": {
           name: "Albuquerque, NM",
           latitudeRad: D2R * 35.106766,
           longitudeRad: D2R * -106.629181,
           eclipseFracion: 0.97
         },
-        {
+        "Eugene, OR": {
           name: "Eugene, OR",
           latitudeRad: D2R * 44.052069,
           longitudeRad: D2R * -123.086754,
           eclipseFracion: .95
         },
-        {
+        "Las Vegas, NV": {
           name: "Las Vegas, NV",
           latitudeRad: D2R * 36.169941,
           longitudeRad: D2R * -115.139830,
           eclipseFracion: .87
         },
-        {
+        "Denver, CO": {
           name: "Denver, CO",
           latitudeRad: D2R * 39.739235,
           longitudeRad: D2R * -104.990250,
           eclipseFracion: .85
         },
-        {
+        "Los Angeles, CA": {
           name: "Los Angeles, CA",
           latitudeRad: D2R * 34.05,
           longitudeRad: D2R * -118.24,
           eclipseFracion: .78
         },
-        {
+        "Omaha, NE": {
           name: "Omaha, NE",
           latitudeRad: D2R * 41.256538,
           longitudeRad: D2R * -95.934502,
           eclipseFracion: .68
         },
-        {
+        "Chicago, IL": {
           name: "Chicago, IL",
           latitudeRad: D2R * 41.878113,
           longitudeRad: D2R * -87.629799,
           eclipseFracion: .54
         },
-        {
+        "New York, NY": {
           name: "New York, NY",
           latitudeRad: D2R * 40.712776,
           longitudeRad: D2R * -74.005974,
           eclipseFracion: .35
         },
-        {
+        "Boston, MA": {
           name: "Boston, MA",
           latitudeRad: D2R * 42.360081,
           longitudeRad: D2R * -71.058884,
           eclipseFracion: .29
         },
-      ],
-      
+        "User Selected": { // by default, user selected is Albaquerque
+          name: "User Selected",
+          latitudeRad: D2R * 35.106766,
+          longitudeRad: D2R * -106.629181,
+          eclipseFracion: 0.97
+        }
+      } as Record<string, EclipseLocation>,
       playing: false,
       playingIntervalId: null as ReturnType<typeof setInterval> | null,
       playingWaitCount: 0,
@@ -790,12 +800,20 @@ export default defineComponent({
       }
     },
 
-    //eslint-disable-next-line
-    updateLocation(location: LocationRad | null) {
+
+
+    updateLocation(location: string) {
       if (location == null) {
         return;
       }
-      
+      console.log("updateLocation", location);
+      this.selectedLocation = location;
+      this.location = {
+        latitudeRad: this.eclipsePathLocations[location].latitudeRad,
+        longitudeRad: this.eclipsePathLocations[location].longitudeRad
+      };
+
+    },
       this.location = {
         latitudeRad: location.latitudeRad,
         longitudeRad: location.longitudeRad
@@ -1100,6 +1118,14 @@ export default defineComponent({
       this.$nextTick(() => {
         this.updateHorizon();
       });
+    },
+
+    selectedLocation(locname: string) {
+      if (!(locname in this.eclipsePathLocations)) {
+        console.log(`location ${locname} not found in eclipsePathLocations`);
+        return;
+      }
+      console.log("selected location", locname);
     },
     
     playing(play: boolean) {
@@ -1592,7 +1618,7 @@ video {
 
 #eclipse-location-selector {
   position: fixed;
-  top: 25%;
+  bottom: 100%;
   left: 50%;
   transform: translateX(-50%) translateY(-50%);
   width: 400px;

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -827,10 +827,8 @@ export default defineComponent({
       }
       console.log("updateLocationFromMap", location);
       this.selectedLocation = 'User Selected';
-      this.location = {
-        latitudeRad: D2R * location.latitudeDeg,
-        longitudeRad: D2R * location.longitudeDeg
-      };
+      this.locationDeg = location;
+
       this.eclipsePathLocations['User Selected'] = {
         name: `User Selected: ${location.latitudeDeg.toFixed(2)}, ${location.longitudeDeg.toFixed(2)}`,
         latitudeRad: D2R * location.latitudeDeg,

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -62,8 +62,8 @@
         <!-- read https://github.com/cosmicds/minids/pull/141 for component description -->
         <location-selector
           :activator-color="accentColor"
-          @location-change="updateLocationFromMap"
-          :initialLocation="locationDeg"
+          @update:modelValue="updateLocationFromMap"
+          :model-value="locationDeg"
         >
         </location-selector>    
         <icon-button
@@ -436,10 +436,6 @@ type LocationDeg = {
   latitudeDeg: number;
 };
 
-type LocationDegTZ = {
-  location: LocationDeg;
-  timezone: string;
-};
 
 type EquatorialRad = {
   raRad: number;
@@ -662,7 +658,7 @@ export default defineComponent({
 
     dateTime() {
       return new Date(this.selectedTime);
-    },    
+    },
 
     selectedTimezoneOffset() {
       return getTimezoneOffset(this.selectedTimezone);
@@ -703,7 +699,7 @@ export default defineComponent({
     // },
     dayFrac(): number {
       const dateForTOD = new Date();
-      const timezoneOffsetHours = this.selectedTimezoneOffset / (60*60*1000);
+      const timezoneOffsetHours = this.selectedTimezoneOffset / (60 * 60 * 1000);
       dateForTOD.setUTCHours(this.timeOfDay.hours - timezoneOffsetHours, this.timeOfDay.minutes, this.timeOfDay.seconds);
       const todMs = 1000 * (3600 * dateForTOD.getUTCHours() + 60 * dateForTOD.getUTCMinutes() + dateForTOD.getUTCSeconds());
       return todMs / MILLISECONDS_PER_DAY;
@@ -729,12 +725,20 @@ export default defineComponent({
       }
     },
 
-    locationDeg(): LocationDeg {
-      return {
-        latitudeDeg: R2D * this.location.latitudeRad,
-        longitudeDeg: R2D * this.location.longitudeRad
-      };
-    },
+    locationDeg: {
+      get(): LocationDeg {
+        return {
+          latitudeDeg: R2D * this.location.latitudeRad,
+          longitudeDeg: R2D * this.location.longitudeRad
+        };
+      },
+      set(value: LocationDeg) {
+        this.location = {
+          latitudeRad: D2R * value.latitudeDeg,
+          longitudeRad: D2R * value.longitudeDeg
+        };
+      }
+    }
   },
 
   methods: {
@@ -817,20 +821,20 @@ export default defineComponent({
 
     },
 
-    updateLocationFromMap(location: LocationDegTZ) {
+    updateLocationFromMap(location: LocationDeg) {
       if (location == null) {
         return;
       }
       console.log("updateLocationFromMap", location);
       this.selectedLocation = 'User Selected';
       this.location = {
-        latitudeRad: D2R * location.location.latitudeDeg,
-        longitudeRad: D2R * location.location.longitudeDeg
+        latitudeRad: D2R * location.latitudeDeg,
+        longitudeRad: D2R * location.longitudeDeg
       };
       this.eclipsePathLocations['User Selected'] = {
-        name: `User Selected: ${location.location.latitudeDeg.toFixed(2)}, ${location.location.longitudeDeg.toFixed(2)}`,
-        latitudeRad: D2R * location.location.latitudeDeg,
-        longitudeRad: D2R * location.location.longitudeDeg,
+        name: `User Selected: ${location.latitudeDeg.toFixed(2)}, ${location.longitudeDeg.toFixed(2)}`,
+        latitudeRad: D2R * location.latitudeDeg,
+        longitudeRad: D2R * location.longitudeDeg,
         eclipseFracion: null
       };
 

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -493,7 +493,7 @@ export default defineComponent({
     sunPlace.set_zoomLevel(20);
 
     return {
-      showSplashScreen: false,
+      showSplashScreen: true,
       backgroundImagesets: [] as BackgroundImageset[],
       sheet: null as SheetType,
       layersLoaded: false,
@@ -504,7 +504,7 @@ export default defineComponent({
       showTextTooltip: false,
       showVideoTooltip: false,
       showControls: true,   
-      showLocationSelector: true,
+      showLocationSelector: false,
 
       selectionProximity: 4,
       pointerMoveThreshold: 6,

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -59,8 +59,11 @@
         </icon-button>
       </div>
       <div id="center-buttons">
+        <!-- read https://github.com/cosmicds/minids/pull/141 for component description -->
         <location-selector
           :activator-color="accentColor"
+          @location-change="updateLocationFromMap"
+          :initialLocation="locationDeg"
         >
         </location-selector>    
     
@@ -68,7 +71,6 @@
       <div id="right-buttons">
         <v-dialog
           v-model="showLocationSelector"
-          fullscreen
           >
           <template v-slot:activator>
             <icon-button
@@ -445,6 +447,16 @@ interface EclipseLocation extends LocationRad {
   eclipseFracion: number | null;
 }
 
+type LocationDeg = {
+  longitudeDeg: number;
+  latitudeDeg: number;
+};
+
+type LocationDegTZ = {
+  location: LocationDeg;
+  timezone: string;
+};
+
 type EquatorialRad = {
   raRad: number;
   decRad: number;
@@ -757,7 +769,14 @@ export default defineComponent({
           video.pause();
         }
       }
-    }
+    },
+
+    locationDeg(): LocationDeg {
+      return {
+        latitudeDeg: R2D * this.location.latitudeRad,
+        longitudeDeg: R2D * this.location.longitudeRad
+      };
+    },
   },
 
   methods: {
@@ -814,14 +833,24 @@ export default defineComponent({
       };
 
     },
+
+    updateLocationFromMap(location: LocationDegTZ) {
+      if (location == null) {
+        return;
+      }
+      console.log("updateLocationFromMap", location);
+      this.selectedLocation = 'User Selected';
       this.location = {
-        latitudeRad: location.latitudeRad,
-        longitudeRad: location.longitudeRad
+        latitudeRad: D2R * location.location.latitudeDeg,
+        longitudeRad: D2R * location.location.longitudeDeg
+      };
+      this.eclipsePathLocations['User Selected'] = {
+        name: `User Selected: ${location.location.latitudeDeg.toFixed(2)}, ${location.location.longitudeDeg.toFixed(2)}`,
+        latitudeRad: D2R * location.location.latitudeDeg,
+        longitudeRad: D2R * location.location.longitudeDeg,
+        eclipseFracion: null
       };
 
-      console.log("location", this.location);
-      this.updateWWTLocation();
-      this.updateHorizon();
     },
 
     onTimeSliderChange() {

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -66,21 +66,34 @@
     
       </div>
       <div id="right-buttons">
+        <v-dialog
+          v-model="showLocationSelector"
+          fullscreen
+          >
+          <template v-slot:activator>
+            <icon-button
+              v-model="showLocationSelector"
+              fa-icon="map-location-dot"
+              :color="accentColor"
+              tooltip-text="Select location"
+              tooltip-location="end"
+              ></icon-button>
+          </template>
+            <div id="eclipse-location-selector">
+              <v-select
+                :items="eclipsePathLocations"
+                item-title="name"
+                :return-object="true"
+                label="Select eclipse viewing location"
+                :color="accentColor"
+                @update:model-value="updateLocation"
+              >
+              </v-select>
+            </div>
+        </v-dialog>
       </div>
     </div>
     
-    <div id="eclipse-location-selector">
-      <v-select
-        :items="eclipsePathLocations"
-        item-title="name"
-        :return-object="true"
-        label="Select eclipse viewing location"
-        :color="accentColor"
-        :dense="true"
-        @update:model-value="updateLocation"
-      >
-      </v-select>
-    </div>
 
     <div class="bottom-content">
       <div
@@ -481,7 +494,7 @@ export default defineComponent({
     console.log("min max date", minutc.toUTCString(), maxutc.toUTCString());
     console.log("date:", now);
     return {
-      showSplashScreen: true,
+      showSplashScreen: false,
       backgroundImagesets: [] as BackgroundImageset[],
       sheet: null as SheetType,
       layersLoaded: false,
@@ -492,6 +505,7 @@ export default defineComponent({
       showTextTooltip: false,
       showVideoTooltip: false,
       showControls: true,   
+      showLocationSelector: true,
 
       selectionProximity: 4,
       pointerMoveThreshold: 6,
@@ -1577,10 +1591,12 @@ video {
 }
 
 #eclipse-location-selector {
-  position: absolute;
+  position: fixed;
   top: 25%;
-  left: 1em;
-  width: 300px;
+  left: 50%;
+  transform: translateX(-50%) translateY(-50%);
+  width: 400px;
+  max-width: 90%;
   background-color: rgba(0, 0, 0, 0.7);
 }
 

--- a/annular-eclipse-2023/src/main.ts
+++ b/annular-eclipse-2023/src/main.ts
@@ -29,6 +29,7 @@ import {
   faClock,
   faPlay,
   faPause,
+  faMapLocationDot
 } from "@fortawesome/free-solid-svg-icons";
 
 library.add(faBookOpen);
@@ -39,6 +40,7 @@ library.add(faChevronDown);
 library.add(faClock);
 library.add(faPlay);
 library.add(faPause);
+library.add(faMapLocationDot);
 
 /** v-hide directive taken from https://www.ryansouthgate.com/2020/01/30/vue-js-v-hide-element-whilst-keeping-occupied-space/ */
 // Extract the function out, up here, so I'm not writing it twice


### PR DESCRIPTION
This uses the same location setting apparatus as the green-comet. There is a list of eclipse locations with their eclipse fractions. Fixing #161 

Right now there is no indication of what eclipse fraction they should expect to see for a location? Perhaps this is better as some type of table showing, or perhaps what is shown in the list can be adjusted using a slot....



![image](https://github.com/cosmicds/minids/assets/7862929/6e657918-6b7a-4ae5-9b55-0b532e13e2db)
