### PR TITLE
Retain Green Comet control panel size when re-opened on Safari

### DIFF
--- a/green-comet/src/C2022E3.vue
+++ b/green-comet/src/C2022E3.vue
@@ -2036,6 +2036,7 @@ body {
   margin-right: 1rem;
   margin-bottom: 1rem;
   pointer-events: auto;
+  width: fit-content;
 
   .v-label {
     color: var(--comet-color);


### PR DESCRIPTION
On Safari, the Green Comet control panel looks fine when the page is first loaded, but if the controls are closed and re-opened, the box is too thin and the panel is basically unusable. This PR adds some CSS to fix this on Safari without changing things on other browsers.