### PR TITLE
Set up z-orders of items in Eclipse mini

### DIFF
--- a/annular-eclipse-2023/package.json
+++ b/annular-eclipse-2023/package.json
@@ -11,10 +11,10 @@
     "webpack-plugin-vuetify": "^2.0.1"
   },
   "scripts": {
-    "build": "vue-cli-service build",
+    "build": "./patch.sh; vue-cli-service build",
     "clean": "rimraf dist",
     "lint": "vue-cli-service lint src --no-fix",
-    "serve": "vue-cli-service serve"
+    "serve": "./patch.sh; vue-cli-service serve"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.5.0",

--- a/annular-eclipse-2023/patch.sh
+++ b/annular-eclipse-2023/patch.sh
@@ -5,15 +5,12 @@ if ! test -f ${filepath}; then
     filepath="../${filepath}"
 fi
 
-line_number=$(sed -n "/TileCache: /=" ${filepath})
-if [[ ! -z ${line_number} ]]
+reexport_line=$(sed -n "/ ss: () => (\/\* reexport/=" $filepath)
+reexport_line=$((${reexport_line} - 1))
+if [[ ! -z ${reexport_line} ]]
 then
-    line=$(head -n ${line_number} ${filepath} | tail -1 | xargs)
-    insert_number=$(sed -n "/ScaleTypes: ScaleTypes/=" ${filepath})
-    if [[ $(($line_number < $insert_number)) ]]
-    then
-        sed -i.bak "${insert_number}a      TileCache: [ TileCache, TileCache$, null ]," ${filepath}
-        sed -i.bak "${line_number}d" ${filepath}
-        rm ${filepath}.bak
-    fi
+    sed -i.bak "${reexport_line}a TileCache: () => (_tile_cache_js__WEBPACK_IMPORTED_MODULE_X__.TileCache)," ${filepath}
+    import_line=$((reexport_line + 5))
+    sed -i.bak "${import_line}a var _tile_cache_js__WEBPACK_IMPORTED_MODULE_X__ = __webpack_require__('./esm/tile_cache.js');" ${filepath}
+    rm ${filepath}.bak
 fi

--- a/annular-eclipse-2023/patch.sh
+++ b/annular-eclipse-2023/patch.sh
@@ -1,10 +1,19 @@
 #!/bin/bash
 
-filepath=../node_modules/@wwtelescope/engine/src/index.js
-line=$(head -n 48377 ${filepath} | tail -1 | xargs)
-if [[ $line = TileCache* ]]
+filepath=node_modules/@wwtelescope/engine/src/index.js
+if ! test -f ${filepath}; then
+    filepath="../${filepath}"
+fi
+
+line_number=$(sed -n "/TileCache: /=" ${filepath})
+if [[ ! -z ${line_number} ]]
 then
-    sed -i.bak '48389a      TileCache: [ TileCache, TileCache$, null ],' ${filepath}
-    sed -i.bak '48377d' ${filepath}
-    rm ${filepath}.bak
+    line=$(head -n ${line_number} ${filepath} | tail -1 | xargs)
+    insert_number=$(sed -n "/ScaleTypes: ScaleTypes/=" ${filepath})
+    if [[ $(($line_number < $insert_number)) ]]
+    then
+        sed -i.bak "${insert_number}a      TileCache: [ TileCache, TileCache$, null ]," ${filepath}
+        sed -i.bak "${line_number}d" ${filepath}
+        rm ${filepath}.bak
+    fi
 fi

--- a/annular-eclipse-2023/patch.sh
+++ b/annular-eclipse-2023/patch.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+filepath=../node_modules/@wwtelescope/engine/src/index.js
+line=$(head -n 48377 ${filepath} | tail -1 | xargs)
+if [[ $line = TileCache* ]]
+then
+    sed -i.bak '48389a      TileCache: [ TileCache, TileCache$, null ],' ${filepath}
+    sed -i.bak '48377d' ${filepath}
+    rm ${filepath}.bak
+fi

--- a/annular-eclipse-2023/patch.sh
+++ b/annular-eclipse-2023/patch.sh
@@ -9,8 +9,12 @@ reexport_line=$(sed -n "/ ss: () => (\/\* reexport/=" $filepath)
 reexport_line=$((${reexport_line} - 1))
 if [[ ! -z ${reexport_line} ]]
 then
-    sed -i.bak "${reexport_line}a TileCache: () => (_tile_cache_js__WEBPACK_IMPORTED_MODULE_X__.TileCache)," ${filepath}
+    sed -i.bak "${reexport_line}a\\
+        TileCache: () => (_tile_cache_js__WEBPACK_IMPORTED_MODULE_X__.TileCache),
+        " ${filepath}
     import_line=$((reexport_line + 5))
-    sed -i.bak "${import_line}a var _tile_cache_js__WEBPACK_IMPORTED_MODULE_X__ = __webpack_require__('./esm/tile_cache.js');" ${filepath}
+    sed -i.bak "${import_line}a\\
+        var _tile_cache_js__WEBPACK_IMPORTED_MODULE_X__ = __webpack_require__('./esm/tile_cache.js');
+        " ${filepath}
     rm ${filepath}.bak
 fi

--- a/annular-eclipse-2023/src/Annotation2.js
+++ b/annular-eclipse-2023/src/Annotation2.js
@@ -1,0 +1,249 @@
+import { Color, Colors, Coordinates, PointList, LineList, TriangleFanList, TriangleList, Tessellator } from "@wwtelescope/engine";
+
+export function Annotation2() {
+    this.addedToPrimitives = false;
+    this.annotationDirty = true;
+    this._opacity = 1;
+    this._showHoverLabel = false;
+}
+
+Annotation2.pointList = null;
+Annotation2.lineList = null;
+Annotation2.triangleFanPointList = null;
+Annotation2.triangleList = null;
+Annotation2.batchDirty = true;
+
+Annotation2.prepBatch = function (renderContext) {
+    if (Annotation2.pointList == null || Annotation2.batchDirty) {
+        Annotation2.pointList = new PointList(renderContext);
+        Annotation2.lineList = new LineList();
+        Annotation2.triangleFanPointList = new TriangleFanList();
+        Annotation2.triangleList = new TriangleList();
+        Annotation2.lineList.set_depthBuffered(false);
+        Annotation2.triangleList.depthBuffered = false;
+    }
+};
+
+Annotation2.drawBatch = function (renderContext) {
+    Annotation2.batchDirty = false;
+    if (renderContext.gl == null) {
+        return;
+    }
+    if (Annotation2.pointList != null) {
+        Annotation2.pointList.draw(renderContext, 1, false);
+    }
+    if (Annotation2.lineList != null) {
+        Annotation2.lineList.drawLines(renderContext, 1);
+    }
+    if (Annotation2.triangleFanPointList != null) {
+        Annotation2.triangleFanPointList.draw(renderContext, 1);
+    }
+    if (Annotation2.triangleList != null) {
+        Annotation2.triangleList.draw(renderContext, 1, 0);
+    }
+};
+
+Annotation2.separation = function (Alpha1, Delta1, Alpha2, Delta2) {
+    Delta1 = Delta1 / 180 * Math.PI;
+    Delta2 = Delta2 / 180 * Math.PI;
+    Alpha1 = Alpha1 / 12 * Math.PI;
+    Alpha2 = Alpha2 / 12 * Math.PI;
+    var x = Math.cos(Delta1) * Math.sin(Delta2) - Math.sin(Delta1) * Math.cos(Delta2) * Math.cos(Alpha2 - Alpha1);
+    var y = Math.cos(Delta2) * Math.sin(Alpha2 - Alpha1);
+    var z = Math.sin(Delta1) * Math.sin(Delta2) + Math.cos(Delta1) * Math.cos(Delta2) * Math.cos(Alpha2 - Alpha1);
+    var vvalue = Math.atan2(Math.sqrt(x * x + y * y), z);
+    vvalue = vvalue / Math.PI * 180;
+    if (vvalue < 0) {
+        vvalue += 180;
+    }
+    return vvalue;
+};
+
+Annotation2.colorToUint = function (col) {
+    return (col.a) << 24 | (col.r << 16) | (col.g) << 8 | col.b;
+};
+
+Annotation2.colorToUintAlpha = function (col, opacity) {
+    return opacity << 24 | col.r << 16 | col.g << 8 | col.b;
+};
+
+var Annotation2$ = {
+    draw: function (renderContext) { },
+
+    get_opacity: function () {
+        return this._opacity;
+    },
+
+    set_opacity: function (value) {
+        Annotation2.batchDirty = true;
+        this._opacity = value;
+        return value;
+    },
+
+    get_id: function () {
+        return this._id;
+    },
+
+    set_id: function (value) {
+        this._id = value;
+        return value;
+    },
+
+    get_tag: function () {
+        return this._tag;
+    },
+
+    set_tag: function (value) {
+        this._tag = value;
+        return value;
+    },
+
+    get_label: function () {
+        return this._label;
+    },
+
+    set_label: function (value) {
+        this._label = value;
+        return value;
+    },
+
+    get_showHoverLabel: function () {
+        return this._showHoverLabel;
+    },
+
+    set_showHoverLabel: function (value) {
+        this._showHoverLabel = value;
+        return value;
+    },
+
+    hitTest: function (renderContext, RA, dec, x, y) {
+        return false;
+    },
+
+    get_center: function () {
+        return this.center;
+    },
+
+    set_center: function (value) {
+        this.center = value;
+        return value;
+    }
+};
+
+
+export function Poly2() {
+    this._points$1 = [];
+    this._fill$1 = false;
+    this._strokeWidth$1 = 1;
+    this._lineColor$1 = Colors.get_white();
+    this._fillColor$1 = Colors.get_white();
+    Annotation2.call(this);
+}
+
+var Poly2$ = {
+    addPoint: function (x, y) {
+        Annotation2.batchDirty = true;
+        this._points$1.push(Coordinates.raDecTo3d(x / 15, y));
+    },
+
+    get_fill: function () {
+        return this._fill$1;
+    },
+
+    set_fill: function (value) {
+        Annotation2.batchDirty = true;
+        this._fill$1 = value;
+        return value;
+    },
+
+    get_lineWidth: function () {
+        return this._strokeWidth$1;
+    },
+
+    set_lineWidth: function (value) {
+        Annotation2.batchDirty = true;
+        this._strokeWidth$1 = value;
+        return value;
+    },
+
+    get_lineColor: function () {
+        return this._lineColor$1.toString();
+    },
+
+    set_lineColor: function (value) {
+        Annotation2.batchDirty = true;
+        this._lineColor$1 = Color.fromName(value);
+        return value;
+    },
+
+    get_fillColor: function () {
+        return this._fillColor$1.toString();
+    },
+
+    set_fillColor: function (value) {
+        Annotation2.batchDirty = true;
+        this._fillColor$1 = Color.fromName(value);
+        return value;
+    },
+
+    draw: function (renderContext) {
+        if (renderContext.gl != null) {
+            if (Annotation2.batchDirty || this.annotationDirty) {
+                //todo can we save this work for later?
+                var vertexList = this._points$1;
+
+                if (this._strokeWidth$1 > 0 && this._points$1.length > 1) {
+                    var lineColorWithOpacity = this._lineColor$1._clone();
+                    lineColorWithOpacity.a = Math.round(lineColorWithOpacity.a * this.get_opacity());
+                    for (var i = 0; i < (this._points$1.length - 1); i++) {
+                        Annotation2.lineList.addLine(vertexList[i], vertexList[i + 1], lineColorWithOpacity, new Dates(0, 1));
+                    }
+                    Annotation2.lineList.addLine(vertexList[this._points$1.length - 1], vertexList[0], lineColorWithOpacity, new Dates(0, 1));
+                }
+                if (this._fill$1) {
+                    var fillColorWithOpacity = this._fillColor$1._clone();
+                    fillColorWithOpacity.a = Math.round(fillColorWithOpacity.a * this.get_opacity());
+                    var indexes = Tessellator.tesselateSimplePoly(vertexList);
+                    for (var i = 0; i < indexes.length; i += 3) {
+                        Annotation2.triangleList.addSubdividedTriangles(vertexList[indexes[i]], vertexList[indexes[i + 1]], vertexList[indexes[i + 2]], fillColorWithOpacity, new Dates(0, 1), 2);
+                    }
+                }
+                this.annotationDirty = false;
+            }
+        } else {
+            var ctx = renderContext.device;
+            ctx.save();
+            ctx.globalAlpha = this.get_opacity();
+            ctx.beginPath();
+            var first = true;
+            for (const pnt of this._points$1) {
+                var screenSpacePnt = renderContext.WVP.transform(pnt);
+                if (screenSpacePnt.z < 0) {
+                    ctx.restore();
+                    return;
+                }
+                if (Vector3d.dot(renderContext.get_viewPoint(), pnt) < 0.75) {
+                    ctx.restore();
+                    return;
+                }
+                if (first) {
+                    first = false;
+                    ctx.moveTo(screenSpacePnt.x, screenSpacePnt.y);
+                }
+                else {
+                    ctx.lineTo(screenSpacePnt.x, screenSpacePnt.y);
+                }
+            }
+            ctx.closePath();
+            ctx.lineWidth = this._strokeWidth$1;
+            if (this._fill$1) {
+                ctx.fillStyle = this._fillColor$1.toString();
+                ctx.fill();
+            }
+            ctx.strokeStyle = this._lineColor$1.toString();
+            ctx.globalAlpha = 1;
+            ctx.stroke();
+            ctx.restore();
+        }
+    }
+};

--- a/annular-eclipse-2023/src/Annotation2.ts
+++ b/annular-eclipse-2023/src/Annotation2.ts
@@ -127,6 +127,16 @@ export class Annotation2 {
       this.center = value;
       return value;
   }
+
+  static addAnnotation(ann) {
+    Annotation2.annotations.push(ann);
+    Annotation2.batchDirty = true;
+  }
+
+  static clearAll() {
+    Annotation2.annotations = [];
+    Annotation2.batchDirty = true;
+  }
 }
 
 export class Poly2 extends Annotation2 {
@@ -244,4 +254,5 @@ export class Poly2 extends Annotation2 {
           ctx.restore();
       }
   }
+
 };

--- a/annular-eclipse-2023/src/Annotation2.ts
+++ b/annular-eclipse-2023/src/Annotation2.ts
@@ -1,3 +1,7 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+/* eslint-disable */
+
 import { Color, Colors, Coordinates, PointList, LineList, TriangleFanList, TriangleList, Tessellator } from "@wwtelescope/engine";
 
 export function Annotation2() {
@@ -6,6 +10,8 @@ export function Annotation2() {
     this._opacity = 1;
     this._showHoverLabel = false;
 }
+
+Annotation2.annotations = [];
 
 Annotation2.pointList = null;
 Annotation2.lineList = null;

--- a/annular-eclipse-2023/src/Annotation2.ts
+++ b/annular-eclipse-2023/src/Annotation2.ts
@@ -2,24 +2,23 @@
 // @ts-nocheck
 /* eslint-disable */
 
-import { Color, Colors, Coordinates, PointList, LineList, TriangleFanList, TriangleList, Tessellator } from "@wwtelescope/engine";
+import { Color, Colors, Coordinates, Dates, PointList, LineList, TriangleFanList, TriangleList, Tessellator } from "@wwtelescope/engine";
 
-export function Annotation2() {
+export class Annotation2 {
+  constructor() {
     this.addedToPrimitives = false;
     this.annotationDirty = true;
     this._opacity = 1;
     this._showHoverLabel = false;
-}
+  }
 
-Annotation2.annotations = [];
+  static annotations = [];
+  static lineList = null;
+  static triangleFanPointList = null;
+  static triangleList = null;
+  static batchDirty = true;
 
-Annotation2.pointList = null;
-Annotation2.lineList = null;
-Annotation2.triangleFanPointList = null;
-Annotation2.triangleList = null;
-Annotation2.batchDirty = true;
-
-Annotation2.prepBatch = function (renderContext) {
+  static prepBatch(renderContext) {
     if (Annotation2.pointList == null || Annotation2.batchDirty) {
         Annotation2.pointList = new PointList(renderContext);
         Annotation2.lineList = new LineList();
@@ -28,9 +27,10 @@ Annotation2.prepBatch = function (renderContext) {
         Annotation2.lineList.set_depthBuffered(false);
         Annotation2.triangleList.depthBuffered = false;
     }
-};
 
-Annotation2.drawBatch = function (renderContext) {
+  }
+
+  static drawBatch(renderContext) {
     Annotation2.batchDirty = false;
     if (renderContext.gl == null) {
         return;
@@ -47,9 +47,9 @@ Annotation2.drawBatch = function (renderContext) {
     if (Annotation2.triangleList != null) {
         Annotation2.triangleList.draw(renderContext, 1, 0);
     }
-};
+  };
 
-Annotation2.separation = function (Alpha1, Delta1, Alpha2, Delta2) {
+  static separation(Alpha1, Delta1, Alpha2, Delta2) {
     Delta1 = Delta1 / 180 * Math.PI;
     Delta2 = Delta2 / 180 * Math.PI;
     Alpha1 = Alpha1 / 12 * Math.PI;
@@ -63,193 +63,185 @@ Annotation2.separation = function (Alpha1, Delta1, Alpha2, Delta2) {
         vvalue += 180;
     }
     return vvalue;
-};
+  };
 
-Annotation2.colorToUint = function (col) {
+  static colorToUint(col) {
     return (col.a) << 24 | (col.r << 16) | (col.g) << 8 | col.b;
-};
+  }
 
-Annotation2.colorToUintAlpha = function (col, opacity) {
+  static colorToUintAlpha(col, opacity) {
     return opacity << 24 | col.r << 16 | col.g << 8 | col.b;
-};
+  };
 
-var Annotation2$ = {
-    draw: function (renderContext) { },
+  get_opacity() {
+    return this._opacity;
+  }
 
-    get_opacity: function () {
-        return this._opacity;
-    },
+  set_opacity(value) {
+    Annotation2.batchDirty = true;
+    this._opacity = value;
+    return value;
+  }
 
-    set_opacity: function (value) {
-        Annotation2.batchDirty = true;
-        this._opacity = value;
-        return value;
-    },
+  draw(renderContext) {}
 
-    get_id: function () {
-        return this._id;
-    },
+  get_id() { return this._id; }
+  set_id(value) {
+    this._id = value;
+    return value;
+  }
 
-    set_id: function (value) {
-        this._id = value;
-        return value;
-    },
+  get_tag() { return this._tag; }
+  set_tag(value) {
+    this._tag = value;
+    return value;
+  }
 
-    get_tag: function () {
-        return this._tag;
-    },
+  get_label() {
+      return this._label;
+  }
 
-    set_tag: function (value) {
-        this._tag = value;
-        return value;
-    },
+  set_label(value) {
+      this._label = value;
+      return value;
+  }
 
-    get_label: function () {
-        return this._label;
-    },
+  get_showHoverLabel() {
+      return this._showHoverLabel;
+  }
 
-    set_label: function (value) {
-        this._label = value;
-        return value;
-    },
+  set_showHoverLabel(value) {
+      this._showHoverLabel = value;
+      return value;
+  }
 
-    get_showHoverLabel: function () {
-        return this._showHoverLabel;
-    },
+  hitTest(renderContext, RA, dec, x, y) {
+      return false;
+  }
 
-    set_showHoverLabel: function (value) {
-        this._showHoverLabel = value;
-        return value;
-    },
+  get_center() {
+      return this.center;
+  }
 
-    hitTest: function (renderContext, RA, dec, x, y) {
-        return false;
-    },
+  set_center(value) {
+      this.center = value;
+      return value;
+  }
+}
 
-    get_center: function () {
-        return this.center;
-    },
-
-    set_center: function (value) {
-        this.center = value;
-        return value;
-    }
-};
-
-
-export function Poly2() {
+export class Poly2 extends Annotation2 {
+  constructor() {
+    super();
     this._points$1 = [];
     this._fill$1 = false;
     this._strokeWidth$1 = 1;
     this._lineColor$1 = Colors.get_white();
     this._fillColor$1 = Colors.get_white();
-    Annotation2.call(this);
-}
+  }
 
-var Poly2$ = {
-    addPoint: function (x, y) {
-        Annotation2.batchDirty = true;
-        this._points$1.push(Coordinates.raDecTo3d(x / 15, y));
-    },
+  addPoint(x, y) {
+      Annotation2.batchDirty = true;
+      this._points$1.push(Coordinates.raDecTo3d(x / 15, y));
+  }
 
-    get_fill: function () {
-        return this._fill$1;
-    },
+  get_fill() {
+      return this._fill$1;
+  }
 
-    set_fill: function (value) {
-        Annotation2.batchDirty = true;
-        this._fill$1 = value;
-        return value;
-    },
+  set_fill(value) {
+      Annotation2.batchDirty = true;
+      this._fill$1 = value;
+      return value;
+  }
 
-    get_lineWidth: function () {
-        return this._strokeWidth$1;
-    },
+  get_lineWidth() {
+      return this._strokeWidth$1;
+  }
 
-    set_lineWidth: function (value) {
-        Annotation2.batchDirty = true;
-        this._strokeWidth$1 = value;
-        return value;
-    },
+  set_lineWidth(value) {
+      Annotation2.batchDirty = true;
+      this._strokeWidth$1 = value;
+      return value;
+  }
 
-    get_lineColor: function () {
-        return this._lineColor$1.toString();
-    },
+  get_lineColor() {
+      return this._lineColor$1.toString();
+  }
 
-    set_lineColor: function (value) {
-        Annotation2.batchDirty = true;
-        this._lineColor$1 = Color.fromName(value);
-        return value;
-    },
+  set_lineColor(value) {
+      Annotation2.batchDirty = true;
+      this._lineColor$1 = Color.fromName(value);
+      return value;
+  }
 
-    get_fillColor: function () {
-        return this._fillColor$1.toString();
-    },
+  get_fillColor() {
+      return this._fillColor$1.toString();
+  }
 
-    set_fillColor: function (value) {
-        Annotation2.batchDirty = true;
-        this._fillColor$1 = Color.fromName(value);
-        return value;
-    },
+  set_fillColor(value) {
+      Annotation2.batchDirty = true;
+      this._fillColor$1 = Color.fromName(value);
+      return value;
+  }
 
-    draw: function (renderContext) {
-        if (renderContext.gl != null) {
-            if (Annotation2.batchDirty || this.annotationDirty) {
-                //todo can we save this work for later?
-                var vertexList = this._points$1;
+  draw(renderContext) {
+      if (renderContext.gl != null) {
+          if (Annotation2.batchDirty || this.annotationDirty) {
+              //todo can we save this work for later?
+              var vertexList = this._points$1;
 
-                if (this._strokeWidth$1 > 0 && this._points$1.length > 1) {
-                    var lineColorWithOpacity = this._lineColor$1._clone();
-                    lineColorWithOpacity.a = Math.round(lineColorWithOpacity.a * this.get_opacity());
-                    for (var i = 0; i < (this._points$1.length - 1); i++) {
-                        Annotation2.lineList.addLine(vertexList[i], vertexList[i + 1], lineColorWithOpacity, new Dates(0, 1));
-                    }
-                    Annotation2.lineList.addLine(vertexList[this._points$1.length - 1], vertexList[0], lineColorWithOpacity, new Dates(0, 1));
-                }
-                if (this._fill$1) {
-                    var fillColorWithOpacity = this._fillColor$1._clone();
-                    fillColorWithOpacity.a = Math.round(fillColorWithOpacity.a * this.get_opacity());
-                    var indexes = Tessellator.tesselateSimplePoly(vertexList);
-                    for (var i = 0; i < indexes.length; i += 3) {
-                        Annotation2.triangleList.addSubdividedTriangles(vertexList[indexes[i]], vertexList[indexes[i + 1]], vertexList[indexes[i + 2]], fillColorWithOpacity, new Dates(0, 1), 2);
-                    }
-                }
-                this.annotationDirty = false;
-            }
-        } else {
-            var ctx = renderContext.device;
-            ctx.save();
-            ctx.globalAlpha = this.get_opacity();
-            ctx.beginPath();
-            var first = true;
-            for (const pnt of this._points$1) {
-                var screenSpacePnt = renderContext.WVP.transform(pnt);
-                if (screenSpacePnt.z < 0) {
-                    ctx.restore();
-                    return;
-                }
-                if (Vector3d.dot(renderContext.get_viewPoint(), pnt) < 0.75) {
-                    ctx.restore();
-                    return;
-                }
-                if (first) {
-                    first = false;
-                    ctx.moveTo(screenSpacePnt.x, screenSpacePnt.y);
-                }
-                else {
-                    ctx.lineTo(screenSpacePnt.x, screenSpacePnt.y);
-                }
-            }
-            ctx.closePath();
-            ctx.lineWidth = this._strokeWidth$1;
-            if (this._fill$1) {
-                ctx.fillStyle = this._fillColor$1.toString();
-                ctx.fill();
-            }
-            ctx.strokeStyle = this._lineColor$1.toString();
-            ctx.globalAlpha = 1;
-            ctx.stroke();
-            ctx.restore();
-        }
-    }
+              if (this._strokeWidth$1 > 0 && this._points$1.length > 1) {
+                  var lineColorWithOpacity = this._lineColor$1._clone();
+                  lineColorWithOpacity.a = Math.round(lineColorWithOpacity.a * this.get_opacity());
+                  for (var i = 0; i < (this._points$1.length - 1); i++) {
+                      Annotation2.lineList.addLine(vertexList[i], vertexList[i + 1], lineColorWithOpacity, new Dates(0, 1));
+                  }
+                  Annotation2.lineList.addLine(vertexList[this._points$1.length - 1], vertexList[0], lineColorWithOpacity, new Dates(0, 1));
+              }
+              if (this._fill$1) {
+                  var fillColorWithOpacity = this._fillColor$1._clone();
+                  fillColorWithOpacity.a = Math.round(fillColorWithOpacity.a * this.get_opacity());
+                  var indexes = Tessellator.tesselateSimplePoly(vertexList);
+                  for (var i = 0; i < indexes.length; i += 3) {
+                      Annotation2.triangleList.addSubdividedTriangles(vertexList[indexes[i]], vertexList[indexes[i + 1]], vertexList[indexes[i + 2]], fillColorWithOpacity, new Dates(0, 1), 2);
+                  }
+              }
+              this.annotationDirty = false;
+          }
+      } else {
+          var ctx = renderContext.device;
+          ctx.save();
+          ctx.globalAlpha = this.get_opacity();
+          ctx.beginPath();
+          var first = true;
+          for (const pnt of this._points$1) {
+              var screenSpacePnt = renderContext.WVP.transform(pnt);
+              if (screenSpacePnt.z < 0) {
+                  ctx.restore();
+                  return;
+              }
+              if (Vector3d.dot(renderContext.get_viewPoint(), pnt) < 0.75) {
+                  ctx.restore();
+                  return;
+              }
+              if (first) {
+                  first = false;
+                  ctx.moveTo(screenSpacePnt.x, screenSpacePnt.y);
+              }
+              else {
+                  ctx.lineTo(screenSpacePnt.x, screenSpacePnt.y);
+              }
+          }
+          ctx.closePath();
+          ctx.lineWidth = this._strokeWidth$1;
+          if (this._fill$1) {
+              ctx.fillStyle = this._fillColor$1.toString();
+              ctx.fill();
+          }
+          ctx.strokeStyle = this._lineColor$1.toString();
+          ctx.globalAlpha = 1;
+          ctx.stroke();
+          ctx.restore();
+      }
+  }
 };

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -378,12 +378,12 @@ import { defineComponent, PropType } from "vue";
 import { MiniDSBase, BackgroundImageset, skyBackgroundImagesets } from "@minids/common";
 import { GotoRADecZoomParams } from "@wwtelescope/engine-pinia";
 import { Classification, SolarSystemObjects } from "@wwtelescope/engine-types";
-import { Constellations, Folder, Grids, LayerManager, Poly, Settings, WWTControl, Place  } from "@wwtelescope/engine";
+import { Constellations, Folder, Grids, LayerManager, Poly, Settings, WWTControl, Place } from "@wwtelescope/engine";
 
 import { getTimezoneOffset } from "date-fns-tz";
 import tzlookup from "tz-lookup";
 
-import { drawSkyOverlays, initializeConstellationNames, makeAltAzGridText, layerManagerDraw, updateViewParameters } from "./wwt-hacks";
+import { drawSkyOverlays, initializeConstellationNames, makeAltAzGridText, layerManagerDraw, updateViewParameters, renderOneFrame } from "./wwt-hacks";
 
 // interface MoveOptions {
 //   instant?: boolean;
@@ -637,6 +637,10 @@ export default defineComponent({
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       this.wwtControl._updateViewParameters = updateViewParameters.bind(this.wwtControl);
+
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      this.wwtControl.renderOneFrame = renderOneFrame.bind(this.wwtControl);
 
       this.updateWWTLocation();
       this.setClockSync(false); // set to false to pause

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -378,7 +378,7 @@ import { defineComponent, PropType } from "vue";
 import { MiniDSBase, BackgroundImageset, skyBackgroundImagesets } from "@minids/common";
 import { GotoRADecZoomParams } from "@wwtelescope/engine-pinia";
 import { Classification, SolarSystemObjects } from "@wwtelescope/engine-types";
-import { Constellations, Folder, Grids, LayerManager, Poly,Settings, WWTControl, Place  } from "@wwtelescope/engine";
+import { Constellations, Folder, Grids, LayerManager, Poly, Settings, WWTControl, Place  } from "@wwtelescope/engine";
 
 import { getTimezoneOffset } from "date-fns-tz";
 import tzlookup from "tz-lookup";

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -813,8 +813,6 @@ export default defineComponent({
       }
     },
 
-
-
     updateLocation(location: string) {
       if (location == null) {
         return;
@@ -983,7 +981,6 @@ export default defineComponent({
     },
 
     createHorizon(when: Date | null = null) {
-      this.removeHorizon();
 
       const color = '#01362C';
       const date = when || this.dateTime || new Date();
@@ -1017,9 +1014,6 @@ export default defineComponent({
     },
 
     createSky(when: Date | null = null) {
-      // this removes all annotations, so it erases horizon if you create that first.
-      // this.removeHorizon(); 
-
       const color = '#87CEEB';
       // const opacity = 0.5;
       const date = when || this.dateTime || new Date();
@@ -1050,7 +1044,8 @@ export default defineComponent({
 
     },
 
-    removeHorizon() {
+    removeAnnotations() {
+      Annotation2.annotations = [];
       this.clearAnnotations();
     },    
 
@@ -1077,18 +1072,13 @@ export default defineComponent({
     updateForDateTime() {
       this.syncDateTimeWithWWTCurrentTime ? this.setTime(this.dateTime) : null;
       this.updateHorizon(this.dateTime); 
-      // this.showImageForDateTime(this.dateTime);
-      // this.updateViewForDate(options);
-      // this.updateLayersForDate();
     },
 
     updateHorizon(when: Date | null = null) {
+      this.removeAnnotations();
       if (this.showHorizon) {
         this.createHorizon(when);
-        // uncomment next line when we sort out opacity of sky annotation
         this.createSky(when);
-      } else {
-        this.removeHorizon();
       }
     },
 

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -1009,7 +1009,7 @@ export default defineComponent({
 
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
-        Annotation2.annotations.push(poly);
+        Annotation2.addAnnotation(poly);
       }
     },
 
@@ -1045,7 +1045,9 @@ export default defineComponent({
     },
 
     removeAnnotations() {
-      Annotation2.annotations = [];
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      Annotation2.clearAll();
       this.clearAnnotations();
     },    
 

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -609,7 +609,7 @@ export default defineComponent({
 
       console.log("initial camera params RA, Dec:", R2D * this.initialCameraParams.raRad/15, R2D * this.initialCameraParams.decRad);
 
-      console.log(this.dateTime);
+      console.log(this);
       this.setTime(this.dateTime);
 
       this.wwtSettings.set_localHorizonMode(true);
@@ -644,6 +644,8 @@ export default defineComponent({
 
       setTimeout(() => {
         this.trackSun().then(() => this.positionSet = true);
+        this.setForegroundImageByName("DSS (Digitized Sky Survey");
+        this.setBackgroundImageByName("Black Sky Background");
       }, 100);
 
       // If there are layers to set up, do that here!

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -379,6 +379,7 @@ import { MiniDSBase, BackgroundImageset, skyBackgroundImagesets } from "@minids/
 import { GotoRADecZoomParams } from "@wwtelescope/engine-pinia";
 import { Classification, SolarSystemObjects } from "@wwtelescope/engine-types";
 import { Constellations, Folder, Grids, LayerManager, Poly, Settings, WWTControl, Place } from "@wwtelescope/engine";
+import { Annotation2, Poly2 } from "./Annotation2";
 
 import { getTimezoneOffset } from "date-fns-tz";
 import tzlookup from "tz-lookup";
@@ -1001,12 +1002,17 @@ export default defineComponent({
           const raDec = this.horizontalToEquatorial(...point, this.location.latitudeRad, this.location.longitudeRad, date);
           return [R2D * raDec.raRad, R2D * raDec.decRad];
         });
-        const poly = new Poly();
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        const poly = new Poly2();
         points.forEach(point => poly.addPoint(...point));
         poly.set_lineColor(color);
         poly.set_fill(true);
         poly.set_fillColor(color);
-        this.addAnnotation(poly);
+
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        Annotation2.annotations.push(poly);
       }
     },
 

--- a/annular-eclipse-2023/src/shims-wwt.d.ts
+++ b/annular-eclipse-2023/src/shims-wwt.d.ts
@@ -25,4 +25,15 @@ declare module "@wwtelescope/engine" {
     static getPushPinTexture(pinId: number): Texture;
   }
 
+  export class Tile {
+    static tilesInView: number;
+    static tilesTouched: number;
+    static deepestLevel: number;
+  }
+
+  export class TileCache {
+    static getTile(): Tile;
+  }
+
+  export class RenderTriangle {}
 }

--- a/annular-eclipse-2023/src/wwt-hacks.ts
+++ b/annular-eclipse-2023/src/wwt-hacks.ts
@@ -330,31 +330,6 @@ export function renderOneFrame() {
       }
     }
   }
-
-  Annotation2.prepBatch(this.renderContext);
-  for (const item of Annotation2.annotations) {
-    item.draw(this.renderContext);
-    index++;
-  }
-  Annotation2.drawBatch(this.renderContext);
-
-  for (const imageset in this.renderContext.get_catalogHipsImagesets()) {
-    if (imageset.get_hipsProperties().get_catalogSpreadSheetLayer().enabled && imageset.get_hipsProperties().get_catalogSpreadSheetLayer().lastVersion === imageset.get_hipsProperties().get_catalogSpreadSheetLayer().get_version()) {
-      this.renderContext.drawImageSet(imageset, 100);
-    }
-  }
-  if (Settings.get_active().get_showSolarSystem()) {
-    this.constellation = Constellations.containment.findConstellationForPoint(this.renderContext.viewCamera.get_RA(), this.renderContext.viewCamera.get_dec());
-    this._drawSkyOverlays();
-    Planets.drawPlanets(this.renderContext, 1);
-  }
-
-  const worldSave = this.renderContext.get_world();
-  const viewSave = this.renderContext.get_view();
-  const projSave = this.renderContext.get_projection();
-  if (Settings.get_current().get_showCrosshairs()) {
-    this._drawCrosshairs(this.renderContext);
-  }
   if (this.uiController != null) {
     this.uiController.render(this.renderContext);
   }
@@ -375,6 +350,31 @@ export function renderOneFrame() {
       this._drawHoverText(this.renderContext);
     }
   }
+
+  for (const imageset in this.renderContext.get_catalogHipsImagesets()) {
+    if (imageset.get_hipsProperties().get_catalogSpreadSheetLayer().enabled && imageset.get_hipsProperties().get_catalogSpreadSheetLayer().lastVersion === imageset.get_hipsProperties().get_catalogSpreadSheetLayer().get_version()) {
+      this.renderContext.drawImageSet(imageset, 100);
+    }
+  }
+  if (Settings.get_active().get_showSolarSystem()) {
+    this.constellation = Constellations.containment.findConstellationForPoint(this.renderContext.viewCamera.get_RA(), this.renderContext.viewCamera.get_dec());
+    this._drawSkyOverlays();
+    Planets.drawPlanets(this.renderContext, 1);
+  }
+
+  Annotation2.prepBatch(this.renderContext);
+  for (const item of Annotation2.annotations) {
+    item.draw(this.renderContext);
+  }
+  Annotation2.drawBatch(this.renderContext);
+
+  const worldSave = this.renderContext.get_world();
+  const viewSave = this.renderContext.get_view();
+  const projSave = this.renderContext.get_projection();
+  if (Settings.get_current().get_showCrosshairs()) {
+    this._drawCrosshairs(this.renderContext);
+  }
+
   const tilesAllLoaded = !TileCache.get_queueCount();
   this.renderContext.setupMatricesOverlays();
   this._fadeFrame();

--- a/annular-eclipse-2023/src/wwt-hacks.ts
+++ b/annular-eclipse-2023/src/wwt-hacks.ts
@@ -3,7 +3,7 @@
 
 /* eslint-disable */
 
-import { Annotation2, Poly2 } from "./Annotation2";
+import { Annotation2 } from "./Annotation2";
 
 import {
   Annotation, Color, Colors, Constellations, Coordinates, Grids,

--- a/annular-eclipse-2023/src/wwt-hacks.ts
+++ b/annular-eclipse-2023/src/wwt-hacks.ts
@@ -239,3 +239,170 @@ export function updateViewParameters() {
    this.renderContext.viewCamera.rotation = dc * this.renderContext.viewCamera.rotation + oneMinusDragCoefficient * this.renderContext.targetCamera.rotation;
    this.renderContext.viewCamera.angle = dc * this.renderContext.viewCamera.angle + oneMinusDragCoefficient * this.renderContext.targetCamera.angle;
 }
+
+export function renderOneFrame() {
+  if (this.renderContext.get_backgroundImageset() != null) {
+    this.renderType = this.renderContext.get_backgroundImageset().get_dataSetType();
+  } else {
+    this.renderType = 2;
+  }
+
+  var sizeChange = false;
+  if (this.canvas.width !== this.canvas.parentNode.clientWidth) {
+    this.canvas.width = this.canvas.parentNode.clientWidth;
+    sizeChange = true;
+  }
+  if (this.canvas.height !== this.canvas.parentNode.clientHeight) {
+    this.canvas.height = this.canvas.parentNode.clientHeight;
+    sizeChange = true;
+  }
+  if (sizeChange && this.explorer != null) {
+    this.explorer.refresh();
+  }
+  if (this.canvas.width < 1 || this.canvas.height < 1) {
+    return;
+  }
+  if (sizeChange) {
+    this._crossHairs = null;
+  }
+  Tile.lastDeepestLevel = Tile.deepestLevel;
+  RenderTriangle.width = this.renderContext.width = this.canvas.width;
+  RenderTriangle.height = this.renderContext.height = this.canvas.height;
+  Tile.tilesInView = 0;
+  Tile.tilesTouched = 0;
+  Tile.deepestLevel = 0;
+  SpaceTimeController.set_metaNow(Date.now());
+  if (this.get__mover() != null) {
+    SpaceTimeController.set_now(this.get__mover().get_currentDateTime());
+    Planets.updatePlanetLocations(this.get_solarSystemMode());
+    if (this.get__mover() != null) {
+      var newCam = this.get__mover().get_currentPosition();
+      this.renderContext.targetCamera = newCam.copy();
+      this.renderContext.viewCamera = newCam.copy();
+      if (this.renderContext.space && Settings.get_active().get_galacticMode()) {
+        var gPoint = Coordinates.j2000toGalactic(newCam.get_RA() * 15, newCam.get_dec());
+        this.renderContext.targetAlt = this.renderContext.alt = gPoint[1];
+        this.renderContext.targetAz = this.renderContext.az = gPoint[0];
+      }
+      else if (this.renderContext.space && Settings.get_active().get_localHorizonMode()) {
+        var currentAltAz = Coordinates.equitorialToHorizon(Coordinates.fromRaDec(newCam.get_RA(), newCam.get_dec()), SpaceTimeController.get_location(), SpaceTimeController.get_now());
+        this.renderContext.targetAlt = this.renderContext.alt = currentAltAz.get_alt();
+        this.renderContext.targetAz = this.renderContext.az = currentAltAz.get_az();
+      }
+      if (this.get__mover().get_complete()) {
+        WWTControl.scriptInterface._fireArrived(this.get__mover().get_currentPosition().get_RA(), this.get__mover().get_currentPosition().get_dec(), WWTControl.singleton.renderContext.viewCamera.zoom);
+        this.set__mover(null);
+        this._notifyMoveComplete();
+      }
+    }
+  }
+  else {
+    SpaceTimeController.updateClock();
+    Planets.updatePlanetLocations(this.get_solarSystemMode());
+    this._updateViewParameters();
+  }
+  this.renderContext.clear();
+
+  this.renderContext.setupMatricesSpace3d(this.renderContext.width, this.renderContext.height);
+  this.renderContext.drawImageSet(this.renderContext.get_backgroundImageset(), 100);
+  if (this.renderContext.get_foregroundImageset() != null) {
+    if (this.renderContext.get_foregroundImageset().get_dataSetType() !== this.renderContext.get_backgroundImageset().get_dataSetType()) {
+      this.renderContext.set_foregroundImageset(null);
+    }
+    else {
+      if (this.renderContext.viewCamera.opacity !== 100 && this.renderContext.gl == null) {
+        if (this._foregroundCanvas.width !== this.renderContext.width || this._foregroundCanvas.height !== this.renderContext.height) {
+          this._foregroundCanvas.width = ss.truncate(this.renderContext.width);
+          this._foregroundCanvas.height = ss.truncate(this.renderContext.height);
+        }
+        var saveDevice = this.renderContext.device;
+        this._fgDevice.clearRect(0, 0, this.renderContext.width, this.renderContext.height);
+        this.renderContext.device = this._fgDevice;
+        this.renderContext.drawImageSet(this.renderContext.get_foregroundImageset(), 100);
+        this.renderContext.device = saveDevice;
+        this.renderContext.device.save();
+        this.renderContext.device.globalAlpha = this.renderContext.viewCamera.opacity / 100;
+        this.renderContext.device.drawImage(this._foregroundCanvas, 0, 0);
+        this.renderContext.device.restore();
+      }
+      else {
+        this.renderContext.drawImageSet(this.renderContext.get_foregroundImageset(), this.renderContext.viewCamera.opacity);
+      }
+    }
+  }
+
+  var $enum1 = ss.enumerate(this.renderContext.get_catalogHipsImagesets());
+  while ($enum1.moveNext()) {
+    var imageset = $enum1.current;
+    if (imageset.get_hipsProperties().get_catalogSpreadSheetLayer().enabled && imageset.get_hipsProperties().get_catalogSpreadSheetLayer().lastVersion === imageset.get_hipsProperties().get_catalogSpreadSheetLayer().get_version()) {
+      this.renderContext.drawImageSet(imageset, 100);
+    }
+  }
+  if (Settings.get_active().get_showSolarSystem()) {
+    this.constellation = Constellations.containment.findConstellationForPoint(this.renderContext.viewCamera.get_RA(), this.renderContext.viewCamera.get_dec());
+    this._drawSkyOverlays();
+    Planets.drawPlanets(this.renderContext, 1);
+  }
+
+  var worldSave = this.renderContext.get_world();
+  var viewSave = this.renderContext.get_view();
+  var projSave = this.renderContext.get_projection();
+  if (Settings.get_current().get_showCrosshairs()) {
+    this._drawCrosshairs(this.renderContext);
+  }
+  if (this.uiController != null) {
+    this.uiController.render(this.renderContext);
+  }
+  else {
+    var index = 0;
+    Annotation.prepBatch(this.renderContext);
+    var $enum2 = ss.enumerate(this._annotations);
+    while ($enum2.moveNext()) {
+      var item = $enum2.current;
+      item.draw(this.renderContext);
+      index++;
+    }
+    Annotation.drawBatch(this.renderContext);
+    if ((Date.now() - this._lastMouseMove) > 400) {
+      var raDecDown = this.getCoordinatesForScreenPoint(this._hoverTextPoint.x, this._hoverTextPoint.y);
+      this._annotationHover(raDecDown.x, raDecDown.y, this._hoverTextPoint.x, this._hoverTextPoint.y);
+      this._lastMouseMove = new Date(2100, 1, 1);
+    }
+    if (!ss.emptyString(this._hoverText)) {
+      this._drawHoverText(this.renderContext);
+    }
+  }
+  var tilesAllLoaded = !TileCache.get_queueCount();
+  this.renderContext.setupMatricesOverlays();
+  this._fadeFrame();
+  this._frameCount++;
+  TileCache.decimateQueue();
+  TileCache.processQueue(this.renderContext);
+  Tile.currentRenderGeneration++;
+  if (!TourPlayer.get_playing()) {
+    this.set_crossFadeFrame(false);
+  }
+  this.renderContext.set_world(worldSave);
+  this.renderContext.set_view(viewSave);
+  this.renderContext.set_projection(projSave);
+  var now = ss.now();
+  var ms = now - this._lastUpdate;
+  if (ms > 1000) {
+    this._lastUpdate = now;
+    this._frameCount = 0;
+    RenderTriangle.trianglesRendered = 0;
+    RenderTriangle.trianglesCulled = 0;
+  }
+  if (this.capturingVideo) {
+    if ((this.dumpFrameParams != null) && (!this.dumpFrameParams.waitDownload || tilesAllLoaded)) {
+      this.captureFrameForVideo(this._videoBlobReady, this.dumpFrameParams.width, this.dumpFrameParams.height, this.dumpFrameParams.format);
+      SpaceTimeController.nextFrame();
+    }
+    if (SpaceTimeController.get_doneDumping()) {
+      SpaceTimeController.frameDumping = false;
+      SpaceTimeController.cancelFrameDump = false;
+      this.capturingVideo = false;
+    }
+  }
+
+}

--- a/annular-eclipse-2023/src/wwt-hacks.ts
+++ b/annular-eclipse-2023/src/wwt-hacks.ts
@@ -3,10 +3,12 @@
 
 /* eslint-disable */
 
+
+
 import {
-  Color, Colors, Constellations, Coordinates, Grids,
-  LayerManager, LayerMap, PushPin, Settings, SpaceTimeController,
-  SpreadSheetLayer, Text3d, Text3dBatch, URLHelpers,
+  Annotation, Color, Colors, Constellations, Coordinates, Grids,
+  LayerManager, Planets, PushPin, RenderTriangle, Settings, SpaceTimeController,
+  SpreadSheetLayer, Text3d, Text3dBatch, Tile, TileCache, TourPlayer, URLHelpers,
   Vector3d, WWTControl
 } from "@wwtelescope/engine";
 
@@ -174,10 +176,8 @@ export function layerManagerDraw(renderContext, opacity, astronomical, reference
     }
     renderContext.set_nominalRadius(thisMap.frame.meanRadius);
   }
-  //console.log("========");
   for (const layer of LayerManager.get_allMaps()[referenceFrame].layers) {
     if (layer.enabled) {
-      //console.log(layer);
       var layerStart = SpaceTimeController.utcToJulian(layer.get_startTime());
       var layerEnd = SpaceTimeController.utcToJulian(layer.get_endTime());
       var fadeIn = SpaceTimeController.utcToJulian(layer.get_startTime()) - ((layer.get_fadeType() === 1 || layer.get_fadeType() === 3) ? (layer.get_fadeSpan() / 864000000) : 0);
@@ -276,16 +276,16 @@ export function renderOneFrame() {
     SpaceTimeController.set_now(this.get__mover().get_currentDateTime());
     Planets.updatePlanetLocations(this.get_solarSystemMode());
     if (this.get__mover() != null) {
-      var newCam = this.get__mover().get_currentPosition();
+      const newCam = this.get__mover().get_currentPosition();
       this.renderContext.targetCamera = newCam.copy();
       this.renderContext.viewCamera = newCam.copy();
       if (this.renderContext.space && Settings.get_active().get_galacticMode()) {
-        var gPoint = Coordinates.j2000toGalactic(newCam.get_RA() * 15, newCam.get_dec());
+        const gPoint = Coordinates.j2000toGalactic(newCam.get_RA() * 15, newCam.get_dec());
         this.renderContext.targetAlt = this.renderContext.alt = gPoint[1];
         this.renderContext.targetAz = this.renderContext.az = gPoint[0];
       }
       else if (this.renderContext.space && Settings.get_active().get_localHorizonMode()) {
-        var currentAltAz = Coordinates.equitorialToHorizon(Coordinates.fromRaDec(newCam.get_RA(), newCam.get_dec()), SpaceTimeController.get_location(), SpaceTimeController.get_now());
+        const currentAltAz = Coordinates.equitorialToHorizon(Coordinates.fromRaDec(newCam.get_RA(), newCam.get_dec()), SpaceTimeController.get_location(), SpaceTimeController.get_now());
         this.renderContext.targetAlt = this.renderContext.alt = currentAltAz.get_alt();
         this.renderContext.targetAz = this.renderContext.az = currentAltAz.get_az();
       }
@@ -342,9 +342,9 @@ export function renderOneFrame() {
     Planets.drawPlanets(this.renderContext, 1);
   }
 
-  var worldSave = this.renderContext.get_world();
-  var viewSave = this.renderContext.get_view();
-  var projSave = this.renderContext.get_projection();
+  const worldSave = this.renderContext.get_world();
+  const viewSave = this.renderContext.get_view();
+  const projSave = this.renderContext.get_projection();
   if (Settings.get_current().get_showCrosshairs()) {
     this._drawCrosshairs(this.renderContext);
   }
@@ -352,9 +352,9 @@ export function renderOneFrame() {
     this.uiController.render(this.renderContext);
   }
   else {
-    var index = 0;
+    const index = 0;
     Annotation.prepBatch(this.renderContext);
-    for (const item in this._annotations) {
+    for (const item of this._annotations) {
       item.draw(this.renderContext);
       index++;
     }
@@ -368,7 +368,7 @@ export function renderOneFrame() {
       this._drawHoverText(this.renderContext);
     }
   }
-  var tilesAllLoaded = !TileCache.get_queueCount();
+  const tilesAllLoaded = !TileCache.get_queueCount();
   this.renderContext.setupMatricesOverlays();
   this._fadeFrame();
   this._frameCount++;
@@ -381,8 +381,8 @@ export function renderOneFrame() {
   this.renderContext.set_world(worldSave);
   this.renderContext.set_view(viewSave);
   this.renderContext.set_projection(projSave);
-  var now = Date.now();
-  var ms = now - this._lastUpdate;
+  const now = Date.now();
+  const ms = now - this._lastUpdate;
   if (ms > 1000) {
     this._lastUpdate = now;
     this._frameCount = 0;

--- a/annular-eclipse-2023/src/wwt-hacks.ts
+++ b/annular-eclipse-2023/src/wwt-hacks.ts
@@ -312,8 +312,8 @@ export function renderOneFrame() {
     else {
       if (this.renderContext.viewCamera.opacity !== 100 && this.renderContext.gl == null) {
         if (this._foregroundCanvas.width !== this.renderContext.width || this._foregroundCanvas.height !== this.renderContext.height) {
-          this._foregroundCanvas.width = ss.truncate(this.renderContext.width);
-          this._foregroundCanvas.height = ss.truncate(this.renderContext.height);
+          this._foregroundCanvas.width = this.renderContext.width;
+          this._foregroundCanvas.height = this.renderContext.height;
         }
         var saveDevice = this.renderContext.device;
         this._fgDevice.clearRect(0, 0, this.renderContext.width, this.renderContext.height);
@@ -331,9 +331,7 @@ export function renderOneFrame() {
     }
   }
 
-  var $enum1 = ss.enumerate(this.renderContext.get_catalogHipsImagesets());
-  while ($enum1.moveNext()) {
-    var imageset = $enum1.current;
+  for (const imageset in this.renderContext.get_catalogHipsImagesets()) {
     if (imageset.get_hipsProperties().get_catalogSpreadSheetLayer().enabled && imageset.get_hipsProperties().get_catalogSpreadSheetLayer().lastVersion === imageset.get_hipsProperties().get_catalogSpreadSheetLayer().get_version()) {
       this.renderContext.drawImageSet(imageset, 100);
     }
@@ -356,9 +354,7 @@ export function renderOneFrame() {
   else {
     var index = 0;
     Annotation.prepBatch(this.renderContext);
-    var $enum2 = ss.enumerate(this._annotations);
-    while ($enum2.moveNext()) {
-      var item = $enum2.current;
+    for (const item in this._annotations) {
       item.draw(this.renderContext);
       index++;
     }
@@ -368,7 +364,7 @@ export function renderOneFrame() {
       this._annotationHover(raDecDown.x, raDecDown.y, this._hoverTextPoint.x, this._hoverTextPoint.y);
       this._lastMouseMove = new Date(2100, 1, 1);
     }
-    if (!ss.emptyString(this._hoverText)) {
+    if (this._hoverText) {
       this._drawHoverText(this.renderContext);
     }
   }
@@ -385,7 +381,7 @@ export function renderOneFrame() {
   this.renderContext.set_world(worldSave);
   this.renderContext.set_view(viewSave);
   this.renderContext.set_projection(projSave);
-  var now = ss.now();
+  var now = Date.now();
   var ms = now - this._lastUpdate;
   if (ms > 1000) {
     this._lastUpdate = now;

--- a/annular-eclipse-2023/src/wwt-hacks.ts
+++ b/annular-eclipse-2023/src/wwt-hacks.ts
@@ -3,7 +3,7 @@
 
 /* eslint-disable */
 
-
+import { Annotation2, Poly2 } from "./Annotation2";
 
 import {
   Annotation, Color, Colors, Constellations, Coordinates, Grids,
@@ -330,6 +330,13 @@ export function renderOneFrame() {
       }
     }
   }
+
+  Annotation2.prepBatch(this.renderContext);
+  for (const item of Annotation2.annotations) {
+    item.draw(this.renderContext);
+    index++;
+  }
+  Annotation2.drawBatch(this.renderContext);
 
   for (const imageset in this.renderContext.get_catalogHipsImagesets()) {
     if (imageset.get_hipsProperties().get_catalogSpreadSheetLayer().enabled && imageset.get_hipsProperties().get_catalogSpreadSheetLayer().lastVersion === imageset.get_hipsProperties().get_catalogSpreadSheetLayer().get_version()) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -51,25 +51,25 @@ __metadata:
   linkType: hard
 
 "@babel/core@npm:^7.12.16":
-  version: 7.22.15
-  resolution: "@babel/core@npm:7.22.15"
+  version: 7.22.19
+  resolution: "@babel/core@npm:7.22.19"
   dependencies:
     "@ampproject/remapping": ^2.2.0
     "@babel/code-frame": ^7.22.13
     "@babel/generator": ^7.22.15
     "@babel/helper-compilation-targets": ^7.22.15
-    "@babel/helper-module-transforms": ^7.22.15
+    "@babel/helper-module-transforms": ^7.22.19
     "@babel/helpers": ^7.22.15
-    "@babel/parser": ^7.22.15
+    "@babel/parser": ^7.22.16
     "@babel/template": ^7.22.15
-    "@babel/traverse": ^7.22.15
-    "@babel/types": ^7.22.15
+    "@babel/traverse": ^7.22.19
+    "@babel/types": ^7.22.19
     convert-source-map: ^1.7.0
     debug: ^4.1.0
     gensync: ^1.0.0-beta.2
     json5: ^2.2.3
     semver: ^6.3.1
-  checksum: 80b3705f2f809f024ac065d73b9bcde991ac5789c38320e00890862200b1603b68035cba7b13ecd827479c7d9ea9b5998ac0a1b7fd28940bcf587fb1301e994a
+  checksum: d603f6f00b20c1edff6a6c9d32c559d4d09ee873380317271b57322bfb9da4349e59df53a21c65e9e5a1136f52bf612389d798640454e6fd9246a5c6d76b0c5c
   languageName: node
   linkType: hard
 
@@ -133,18 +133,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-module-transforms@npm:^7.22.15":
-  version: 7.22.15
-  resolution: "@babel/helper-module-transforms@npm:7.22.15"
+"@babel/helper-module-transforms@npm:^7.22.19":
+  version: 7.22.19
+  resolution: "@babel/helper-module-transforms@npm:7.22.19"
   dependencies:
     "@babel/helper-environment-visitor": ^7.22.5
     "@babel/helper-module-imports": ^7.22.15
     "@babel/helper-simple-access": ^7.22.5
     "@babel/helper-split-export-declaration": ^7.22.6
-    "@babel/helper-validator-identifier": ^7.22.15
+    "@babel/helper-validator-identifier": ^7.22.19
   peerDependencies:
     "@babel/core": ^7.0.0
-  checksum: de571fa352331bb5d5d56e95239c2e5dd79a1454e5167f3d80820d4975ee95052f8198e9fc1310015c55a0407b7566f8ca9d86cf262046884847aa24f8139bca
+  checksum: ee1278a6850bb5c0efff35c4c20a13469a84d1bdc999a5e1c5aaf87d848b76cba464904c3c34bbbabcbe83e4632a5d7c64ac006de710c5d63c7b2c2473c33f77
   languageName: node
   linkType: hard
 
@@ -173,10 +173,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-validator-identifier@npm:^7.22.15, @babel/helper-validator-identifier@npm:^7.22.5":
-  version: 7.22.15
-  resolution: "@babel/helper-validator-identifier@npm:7.22.15"
-  checksum: eb0bee4bda664c0959924bc1ad5611eacfce806f46612202dd164fef1df8fef1a11682a1e7615288987100e9fb304982b6e2a4ff07ffe842ab8765b95ed1118c
+"@babel/helper-validator-identifier@npm:^7.22.19, @babel/helper-validator-identifier@npm:^7.22.5":
+  version: 7.22.19
+  resolution: "@babel/helper-validator-identifier@npm:7.22.19"
+  checksum: cf1f94d35cdb2d0f519b31954d1c54929fb31cf8af70fed12b3a1e777c296fabe747e56d9ae3d181c1c96f33ac66aff9501189542554b6fe0508748a38c1c17f
   languageName: node
   linkType: hard
 
@@ -209,7 +209,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.20.15, @babel/parser@npm:^7.21.3, @babel/parser@npm:^7.22.15":
+"@babel/parser@npm:^7.20.15, @babel/parser@npm:^7.21.3, @babel/parser@npm:^7.22.15, @babel/parser@npm:^7.22.16":
   version: 7.22.16
   resolution: "@babel/parser@npm:7.22.16"
   bin:
@@ -238,9 +238,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.22.15":
-  version: 7.22.15
-  resolution: "@babel/traverse@npm:7.22.15"
+"@babel/traverse@npm:^7.22.15, @babel/traverse@npm:^7.22.19":
+  version: 7.22.19
+  resolution: "@babel/traverse@npm:7.22.19"
   dependencies:
     "@babel/code-frame": ^7.22.13
     "@babel/generator": ^7.22.15
@@ -248,22 +248,22 @@ __metadata:
     "@babel/helper-function-name": ^7.22.5
     "@babel/helper-hoist-variables": ^7.22.5
     "@babel/helper-split-export-declaration": ^7.22.6
-    "@babel/parser": ^7.22.15
-    "@babel/types": ^7.22.15
+    "@babel/parser": ^7.22.16
+    "@babel/types": ^7.22.19
     debug: ^4.1.0
     globals: ^11.1.0
-  checksum: 12aba7da6fd6109905d5086e1a9d1aea2cdbb0b80533d2d235d5dad2ff97f0315173c063023e601e96086dfeaaeb97f9d3cbaf38a10f04820e47e2848607cef4
+  checksum: 119154fdfffd0fd560d2d5263ae2d740bcd3c75a6c432786f6ccdb28c9b0776f0fe21a16320c81a3e065c37249fb217dfec4201e44058462d26accfcdcd6c9bb
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.22.15, @babel/types@npm:^7.22.5, @babel/types@npm:^7.8.3":
-  version: 7.22.15
-  resolution: "@babel/types@npm:7.22.15"
+"@babel/types@npm:^7.22.15, @babel/types@npm:^7.22.19, @babel/types@npm:^7.22.5, @babel/types@npm:^7.8.3":
+  version: 7.22.19
+  resolution: "@babel/types@npm:7.22.19"
   dependencies:
     "@babel/helper-string-parser": ^7.22.5
-    "@babel/helper-validator-identifier": ^7.22.15
+    "@babel/helper-validator-identifier": ^7.22.19
     to-fast-properties: ^2.0.0
-  checksum: a2aa59746dc8500c358a3a9afca2adff49dbade009d616aa8308714485064f2218da04e1823f1243a4992f1424ec6d6719e76a7af9a0ac3647227dca3015eea4
+  checksum: 2d69740e69b55ba36ece0c17d5afb7b7213b34297157df39ef9ba24965aff677c56f014413052ecc5b2fbbf26910c63e5bb24a969df84d7a17153750cf75915e
   languageName: node
   linkType: hard
 
@@ -293,9 +293,9 @@ __metadata:
   linkType: hard
 
 "@eslint-community/regexpp@npm:^4.4.0, @eslint-community/regexpp@npm:^4.5.1, @eslint-community/regexpp@npm:^4.6.1":
-  version: 4.8.0
-  resolution: "@eslint-community/regexpp@npm:4.8.0"
-  checksum: 601e6d033d556e98e8c929905bef335f20d7389762812df4d0f709d9b4d2631610dda975fb272e23b5b68e24a163b3851b114c8080a0a19fb4c141a1eff6305b
+  version: 4.8.1
+  resolution: "@eslint-community/regexpp@npm:4.8.1"
+  checksum: 82d62c845ef42b810f268cfdc84d803a2da01735fb52e902fd34bdc09f92464a094fd8e4802839874b000b2f73f67c972859e813ba705233515d3e954f234bf2
   languageName: node
   linkType: hard
 
@@ -316,10 +316,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/js@npm:8.48.0":
-  version: 8.48.0
-  resolution: "@eslint/js@npm:8.48.0"
-  checksum: b2755f9c0ee810c886eba3c50dcacb184ba5a5cd1cbc01988ee506ad7340653cae0bd55f1d95c64b56dfc6d25c2caa7825335ffd2c50165bae9996fe0f396851
+"@eslint/js@npm:8.49.0":
+  version: 8.49.0
+  resolution: "@eslint/js@npm:8.49.0"
+  checksum: a6601807c8aeeefe866926ad92ed98007c034a735af20ff709009e39ad1337474243d47908500a3bde04e37bfba16bcf1d3452417f962e1345bc8756edd6b830
   languageName: node
   linkType: hard
 
@@ -383,7 +383,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@humanwhocodes/config-array@npm:^0.11.10":
+"@humanwhocodes/config-array@npm:^0.11.11":
   version: 0.11.11
   resolution: "@humanwhocodes/config-array@npm:0.11.11"
   dependencies:
@@ -824,9 +824,9 @@ __metadata:
   linkType: hard
 
 "@testim/chrome-version@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "@testim/chrome-version@npm:1.1.3"
-  checksum: 0874590ae515c2e9e80d62130cd9be070932b60724cef93217c6d2d62f2776a2a9cbc4ef3548e674f57236a4c75f322ce0df7b5ecfecbc8d8b5e3eeaee92391c
+  version: 1.1.4
+  resolution: "@testim/chrome-version@npm:1.1.4"
+  checksum: 63817db694ab4a49d240217063a30dc2aac9799561132b51da97699207c47cb3355ae043ad1f8b15b770447834cbf36202133641b078f3944d0a502435b40827
   languageName: node
   linkType: hard
 
@@ -1344,9 +1344,9 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:*":
-  version: 20.5.9
-  resolution: "@types/node@npm:20.5.9"
-  checksum: 717490e94131722144878b4ca1a963ede1673bb8f2ef78c2f5b50b918df6dc9b35e7f8283e5c2a7a9f137730f7c08dc6228e53d4494a94c9ee16881e6ce6caed
+  version: 20.6.1
+  resolution: "@types/node@npm:20.6.1"
+  checksum: f9848617221b513d558071c804b006750d1ee1734c5ffea3ada9a0edd1642334ad0812222d6b99b7b8c0e1a5f1e557946ae99444c2705e9afc125abdf9fa36c2
   languageName: node
   linkType: hard
 
@@ -1414,9 +1414,9 @@ __metadata:
   linkType: hard
 
 "@types/semver@npm:^7.3.12, @types/semver@npm:^7.5.0":
-  version: 7.5.1
-  resolution: "@types/semver@npm:7.5.1"
-  checksum: 2fffe938c7ac168711f245a16e1856a3578d77161ca17e29a05c3e02c7be3e9c5beefa29a3350f6c1bd982fb70aa28cc52e4845eb7d36246bcdc0377170d584d
+  version: 7.5.2
+  resolution: "@types/semver@npm:7.5.2"
+  checksum: 743aa8a2b58e20b329c19bd2459152cb049d12fafab7279b90ac11e0f268c97efbcb606ea0c681cca03f79015381b40d9b1244349b354270bec3f939ed49f6e9
   languageName: node
   linkType: hard
 
@@ -1516,14 +1516,14 @@ __metadata:
   linkType: hard
 
 "@typescript-eslint/eslint-plugin@npm:^6.5.0":
-  version: 6.6.0
-  resolution: "@typescript-eslint/eslint-plugin@npm:6.6.0"
+  version: 6.7.0
+  resolution: "@typescript-eslint/eslint-plugin@npm:6.7.0"
   dependencies:
     "@eslint-community/regexpp": ^4.5.1
-    "@typescript-eslint/scope-manager": 6.6.0
-    "@typescript-eslint/type-utils": 6.6.0
-    "@typescript-eslint/utils": 6.6.0
-    "@typescript-eslint/visitor-keys": 6.6.0
+    "@typescript-eslint/scope-manager": 6.7.0
+    "@typescript-eslint/type-utils": 6.7.0
+    "@typescript-eslint/utils": 6.7.0
+    "@typescript-eslint/visitor-keys": 6.7.0
     debug: ^4.3.4
     graphemer: ^1.4.0
     ignore: ^5.2.4
@@ -1536,7 +1536,7 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: ed41c6df87096706777e9c1f53adabd998fd840691b57f5b68b18903e567f16c0a8354ff0ad29229c249f29440ba4a017c9fe966da182a455dde9769232a4344
+  checksum: 48393749c5c1f67acf71795551c6065586198530006189c48636e32caea4d1285624c16c047164f9d29055e26c4f90fca964c5a2b5c0e9b6d9ed87acd74ca0d6
   languageName: node
   linkType: hard
 
@@ -1558,20 +1558,20 @@ __metadata:
   linkType: hard
 
 "@typescript-eslint/parser@npm:^6.5.0":
-  version: 6.6.0
-  resolution: "@typescript-eslint/parser@npm:6.6.0"
+  version: 6.7.0
+  resolution: "@typescript-eslint/parser@npm:6.7.0"
   dependencies:
-    "@typescript-eslint/scope-manager": 6.6.0
-    "@typescript-eslint/types": 6.6.0
-    "@typescript-eslint/typescript-estree": 6.6.0
-    "@typescript-eslint/visitor-keys": 6.6.0
+    "@typescript-eslint/scope-manager": 6.7.0
+    "@typescript-eslint/types": 6.7.0
+    "@typescript-eslint/typescript-estree": 6.7.0
+    "@typescript-eslint/visitor-keys": 6.7.0
     debug: ^4.3.4
   peerDependencies:
     eslint: ^7.0.0 || ^8.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: b2d0082b6acc1a85997ebbb60fc73a43f3fe5e5028cb4130938a2cffddc94872c8e0d00a1742be8f8b755bc1994d43b55b7e4660dc88946744094ff2aca4ffd3
+  checksum: 21d52a49abf78a3b037261c01f1f4d2d550919ddc906ebb058db3410a706457ac3a7d082716328ce98a6741d4e77c945b71ff386d9047c5a2e5beef23e14ab45
   languageName: node
   linkType: hard
 
@@ -1585,13 +1585,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:6.6.0":
-  version: 6.6.0
-  resolution: "@typescript-eslint/scope-manager@npm:6.6.0"
+"@typescript-eslint/scope-manager@npm:6.7.0":
+  version: 6.7.0
+  resolution: "@typescript-eslint/scope-manager@npm:6.7.0"
   dependencies:
-    "@typescript-eslint/types": 6.6.0
-    "@typescript-eslint/visitor-keys": 6.6.0
-  checksum: 18b552fee98894c4f35e9f3d71a276f266ad4e2d7c6b9bb32a9b25caa36cc3768928676972b4e78308098ad53fa8dc6626a82810f17d51c667ce959da3ac11bc
+    "@typescript-eslint/types": 6.7.0
+    "@typescript-eslint/visitor-keys": 6.7.0
+  checksum: f6ea33c647783d53d98938bd5d3fc94c9a5ebc83bd64cf379215863921dd1c57e66c33af7948d6ac1884623e1917a3b42565e6d02e1fd7adfbce4b3424a2382e
   languageName: node
   linkType: hard
 
@@ -1612,12 +1612,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:6.6.0":
-  version: 6.6.0
-  resolution: "@typescript-eslint/type-utils@npm:6.6.0"
+"@typescript-eslint/type-utils@npm:6.7.0":
+  version: 6.7.0
+  resolution: "@typescript-eslint/type-utils@npm:6.7.0"
   dependencies:
-    "@typescript-eslint/typescript-estree": 6.6.0
-    "@typescript-eslint/utils": 6.6.0
+    "@typescript-eslint/typescript-estree": 6.7.0
+    "@typescript-eslint/utils": 6.7.0
     debug: ^4.3.4
     ts-api-utils: ^1.0.1
   peerDependencies:
@@ -1625,7 +1625,7 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: be68ebc1d8da9d4db48933cfd5c8f22382fdf1faf4116b0eb929c65eaeaf00ef224f38b03e7f6ea2de4496d046380876dd5db514c65d078ebc7a25e771a61265
+  checksum: 15ae33a6981721f83b2ac612a7597a4fcb2d9d9bfedce54707e5228bec2774fd99ba54ffce89924ae36b61488c7b6c0c2165a6d361be5cd4cefebefad8b02a01
   languageName: node
   linkType: hard
 
@@ -1636,10 +1636,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:6.6.0":
-  version: 6.6.0
-  resolution: "@typescript-eslint/types@npm:6.6.0"
-  checksum: d0642ad52e904062a4ac75ac4e6cc51d81ec6030f8830e230df476e69786d3232d45ca0c9ce011add9ede13f0eba4ab7f1eaf679954c6602cf4f43e1ba002be9
+"@typescript-eslint/types@npm:6.7.0":
+  version: 6.7.0
+  resolution: "@typescript-eslint/types@npm:6.7.0"
+  checksum: fb76031432a009813d559b1cc63091eb5434279012cdb98de62fcd556910663c6a1b506e0a77c4f86e223a5e2c00e76a2d1d2170802c75168008d19a52a51fca
   languageName: node
   linkType: hard
 
@@ -1668,12 +1668,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:6.6.0":
-  version: 6.6.0
-  resolution: "@typescript-eslint/typescript-estree@npm:6.6.0"
+"@typescript-eslint/typescript-estree@npm:6.7.0":
+  version: 6.7.0
+  resolution: "@typescript-eslint/typescript-estree@npm:6.7.0"
   dependencies:
-    "@typescript-eslint/types": 6.6.0
-    "@typescript-eslint/visitor-keys": 6.6.0
+    "@typescript-eslint/types": 6.7.0
+    "@typescript-eslint/visitor-keys": 6.7.0
     debug: ^4.3.4
     globby: ^11.1.0
     is-glob: ^4.0.3
@@ -1682,7 +1682,7 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 100620bc5865dc9d2551c6be520a34b931bc70eca144c5ab0e275b81e57aa92f24a9d3a57f332d98b96e4581cf7e87211c3196d964f4951c7a2508105e3bd3f5
+  checksum: 9bd57910085f0dd97d7083e0468c34e0753d20d36d3ffaa4ba111f13cc4986743374f5aed928e645ea982cf2ed9a8141598bee41393cad0abee001f0842ad117
   languageName: node
   linkType: hard
 
@@ -1722,20 +1722,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:6.6.0":
-  version: 6.6.0
-  resolution: "@typescript-eslint/utils@npm:6.6.0"
+"@typescript-eslint/utils@npm:6.7.0":
+  version: 6.7.0
+  resolution: "@typescript-eslint/utils@npm:6.7.0"
   dependencies:
     "@eslint-community/eslint-utils": ^4.4.0
     "@types/json-schema": ^7.0.12
     "@types/semver": ^7.5.0
-    "@typescript-eslint/scope-manager": 6.6.0
-    "@typescript-eslint/types": 6.6.0
-    "@typescript-eslint/typescript-estree": 6.6.0
+    "@typescript-eslint/scope-manager": 6.7.0
+    "@typescript-eslint/types": 6.7.0
+    "@typescript-eslint/typescript-estree": 6.7.0
     semver: ^7.5.4
   peerDependencies:
     eslint: ^7.0.0 || ^8.0.0
-  checksum: da02305703569549eb7deebb7512940cd40426eccec684680087a5b8c8e08052e2ff0ff6951a2ca64740e86e4b5b390903d0b13ad51efc374d9ae54f70c6a046
+  checksum: b2a2857ec856d1752e77c2a274a12513372311c300f9ec57ed7bf7411eb9ea34b85a8e7810a5c48fff0e3966b71d63d77e38c5c7bca1d5c004bede5638619a00
   languageName: node
   linkType: hard
 
@@ -1749,13 +1749,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:6.6.0":
-  version: 6.6.0
-  resolution: "@typescript-eslint/visitor-keys@npm:6.6.0"
+"@typescript-eslint/visitor-keys@npm:6.7.0":
+  version: 6.7.0
+  resolution: "@typescript-eslint/visitor-keys@npm:6.7.0"
   dependencies:
-    "@typescript-eslint/types": 6.6.0
+    "@typescript-eslint/types": 6.7.0
     eslint-visitor-keys: ^3.4.1
-  checksum: 28171124c5c7d5d10c04c204530508f1488214f2af5eb7e64a5f1cc410c64f02676c04be087adcfd0deb5566f5bb7337b208afcb249719614634c38bcc3da897
+  checksum: cd85722d26ccfa23a76e5cb5aa0229f89eb3c4f1ed87d71a0f902db15f420f3f3e94cbd16dc711039f611ac60b1e7d0fee9ee78c48c88310a5f1926a2bc8778e
   languageName: node
   linkType: hard
 
@@ -2355,13 +2355,13 @@ __metadata:
   linkType: hard
 
 "@wwtelescope/engine@npm:^7.18.0, @wwtelescope/engine@npm:^7.27.0":
-  version: 7.28.2
-  resolution: "@wwtelescope/engine@npm:7.28.2"
+  version: 7.29.0
+  resolution: "@wwtelescope/engine@npm:7.29.0"
   dependencies:
     "@wwtelescope/engine-types": ">=0.6.0"
     pako: ^1.0.11
     uuid: ^8.3.2
-  checksum: a64ad14ce5d2f8895f53edad4a37cb236d7bbbbc27464719ef3537765c9fc0fc3f30aa4419ab9d6f3d3e70125840f1d1371312d0139dc879f5e886b2680a5830
+  checksum: e08b57cdcc6418cc5be222ffef8e5bfdb444f79c83134df5ea57d2d7af8dddaf04e8c6128c92775affcb6a7c14535193892b7aee7c827afdf598bfdc584d69e4
   languageName: node
   linkType: hard
 
@@ -2827,9 +2827,9 @@ __metadata:
   linkType: hard
 
 "axe-core@npm:^4.7.2":
-  version: 4.8.0
-  resolution: "axe-core@npm:4.8.0"
-  checksum: c3796c7568d15e865ce08d4745318305d0620530e72870c92d984ba0f6fdf16f24fce3df7d30a63ac79fadc27c331d9d6c875ce8cb818b106e095618e099df9b
+  version: 4.8.1
+  resolution: "axe-core@npm:4.8.1"
+  checksum: 78cc7c19bd98d9fc859e9f08923d12c0023f93c9f807b2eebc2ef7b415d7c7cd0dcda914848fa5443ec4b58a9db879366186528a86e08b1c1b336ee38a029c7e
   languageName: node
   linkType: hard
 
@@ -3179,9 +3179,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001517, caniuse-lite@npm:^1.0.30001520":
-  version: 1.0.30001528
-  resolution: "caniuse-lite@npm:1.0.30001528"
-  checksum: 7b6a71d41de1ce2b95f5851e7074050b7600157acf02c5701d9650a1faf824e368163f4ede5e269d4ea44fe33e00fe60673cb86f40cac35bd02a9a9a4ef7f162
+  version: 1.0.30001534
+  resolution: "caniuse-lite@npm:1.0.30001534"
+  checksum: 8e8b63c1ce0d5b944ee2d8223955b33f3d4f60c33fed394ff6353b5c7106b2dc55219fd07d80c79e66ed1f82ed9367cee17bda96789cbd2ab57c8d30b1b5c510
   languageName: node
   linkType: hard
 
@@ -3392,9 +3392,9 @@ __metadata:
   linkType: hard
 
 "cli-spinners@npm:^2.5.0":
-  version: 2.9.0
-  resolution: "cli-spinners@npm:2.9.0"
-  checksum: a9c56e1f44457d4a9f4f535364e729cb8726198efa9e98990cfd9eda9e220dfa4ba12f92808d1be5e29029cdfead781db82dc8549b97b31c907d55f96aa9b0e2
+  version: 2.9.1
+  resolution: "cli-spinners@npm:2.9.1"
+  checksum: 1780618be58309c469205bc315db697934bac68bce78cd5dfd46248e507a533172d623c7348ecfd904734f597ce0a4e5538684843d2cfb7af485d4466699940c
   languageName: node
   linkType: hard
 
@@ -4473,6 +4473,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"define-data-property@npm:^1.0.1":
+  version: 1.1.0
+  resolution: "define-data-property@npm:1.1.0"
+  dependencies:
+    get-intrinsic: ^1.2.1
+    gopd: ^1.0.1
+    has-property-descriptors: ^1.0.0
+  checksum: 7ad4ee84cca8ad427a4831f5693526804b62ce9dfd4efac77214e95a4382aed930072251d4075dc8dc9fc949a353ed51f19f5285a84a788ba9216cc51472a093
+  languageName: node
+  linkType: hard
+
 "define-lazy-prop@npm:^2.0.0":
   version: 2.0.0
   resolution: "define-lazy-prop@npm:2.0.0"
@@ -4481,12 +4492,13 @@ __metadata:
   linkType: hard
 
 "define-properties@npm:^1.1.3, define-properties@npm:^1.1.4":
-  version: 1.2.0
-  resolution: "define-properties@npm:1.2.0"
+  version: 1.2.1
+  resolution: "define-properties@npm:1.2.1"
   dependencies:
+    define-data-property: ^1.0.1
     has-property-descriptors: ^1.0.0
     object-keys: ^1.1.1
-  checksum: e60aee6a19b102df4e2b1f301816804e81ab48bb91f00d0d935f269bf4b3f79c88b39e4f89eaa132890d23267335fd1140dfcd8d5ccd61031a0a2c41a54e33a6
+  checksum: b4ccd00597dd46cb2d4a379398f5b19fca84a16f3374e2249201992f36b30f6835949a9429669ee6b41b6e837205a163eadd745e472069e70dfc10f03e5fcc12
   languageName: node
   linkType: hard
 
@@ -4742,9 +4754,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.4.477":
-  version: 1.4.510
-  resolution: "electron-to-chromium@npm:1.4.510"
-  checksum: c129dbd5735876fbd25b541cc6fd138914ba8c2189f0c30e2145b645d79d67fcb22f64dc28801ec847e8e71418f89318bd8f0ab02d464979bec2668a06dc4268
+  version: 1.4.522
+  resolution: "electron-to-chromium@npm:1.4.522"
+  checksum: c1e2c7b4d003d03dffcfe782662df1f756b2ee3e17fa5b282b27f65a58085c9f5daa731f2c7347b58bd0d18c15477059c8ccdb60f4ed608d91754cf1afb52178
   languageName: node
   linkType: hard
 
@@ -4871,9 +4883,9 @@ __metadata:
   linkType: hard
 
 "es-module-lexer@npm:^1.2.1":
-  version: 1.3.0
-  resolution: "es-module-lexer@npm:1.3.0"
-  checksum: 48fd9f504a9d2a894126f75c8b7ccc6273a289983e9b67255f165bfd9ae765d50100218251e94e702ca567826905ea2f7b3b4a0c4d74d3ce99cce3a2a606a238
+  version: 1.3.1
+  resolution: "es-module-lexer@npm:1.3.1"
+  checksum: 3beafa7e171eb1e8cc45695edf8d51638488dddf65294d7911f8d6a96249da6a9838c87529262cc6ea53988d8272cec0f4bff93f476ed031a54ba3afb51a0ed3
   languageName: node
   linkType: hard
 
@@ -4984,14 +4996,14 @@ __metadata:
   linkType: hard
 
 "eslint@npm:^8.31.0, eslint@npm:^8.48.0":
-  version: 8.48.0
-  resolution: "eslint@npm:8.48.0"
+  version: 8.49.0
+  resolution: "eslint@npm:8.49.0"
   dependencies:
     "@eslint-community/eslint-utils": ^4.2.0
     "@eslint-community/regexpp": ^4.6.1
     "@eslint/eslintrc": ^2.1.2
-    "@eslint/js": 8.48.0
-    "@humanwhocodes/config-array": ^0.11.10
+    "@eslint/js": 8.49.0
+    "@humanwhocodes/config-array": ^0.11.11
     "@humanwhocodes/module-importer": ^1.0.1
     "@nodelib/fs.walk": ^1.2.8
     ajv: ^6.12.4
@@ -5026,7 +5038,7 @@ __metadata:
     text-table: ^0.2.0
   bin:
     eslint: bin/eslint.js
-  checksum: f20b359a4f8123fec5c033577368cc020d42978b1b45303974acd8da7a27063168ee3fe297ab5b35327162f6a93154063e3ce6577102f70f9809aff793db9bd0
+  checksum: 4dfe257e1e42da2f9da872b05aaaf99b0f5aa022c1a91eee8f2af1ab72651b596366320c575ccd4e0469f7b4c97aff5bb85ae3323ebd6a293c3faef4028b0d81
   languageName: node
   linkType: hard
 
@@ -5703,7 +5715,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-intrinsic@npm:^1.0.2, get-intrinsic@npm:^1.1.1, get-intrinsic@npm:^1.1.3":
+"get-intrinsic@npm:^1.0.2, get-intrinsic@npm:^1.1.1, get-intrinsic@npm:^1.1.3, get-intrinsic@npm:^1.2.1":
   version: 1.2.1
   resolution: "get-intrinsic@npm:1.2.1"
   dependencies:
@@ -9516,28 +9528,28 @@ __metadata:
   linkType: hard
 
 "resolve@npm:^1.10.0":
-  version: 1.22.4
-  resolution: "resolve@npm:1.22.4"
+  version: 1.22.5
+  resolution: "resolve@npm:1.22.5"
   dependencies:
     is-core-module: ^2.13.0
     path-parse: ^1.0.7
     supports-preserve-symlinks-flag: ^1.0.0
   bin:
     resolve: bin/resolve
-  checksum: 23f25174c2736ce24c6d918910e0d1f89b6b38fefa07a995dff864acd7863d59a7f049e691f93b4b2ee29696303390d921552b6d1b841ed4a8101f517e1d0124
+  checksum: 6d8c8e414c0727341bc5b78d3806aa6730975d6c633ff266e90f3502ae1c10353d3535c9810aa94187a32ea192b9b3722afecac67487e27f44e60d89cca45cda
   languageName: node
   linkType: hard
 
 "resolve@patch:resolve@^1.10.0#~builtin<compat/resolve>":
-  version: 1.22.4
-  resolution: "resolve@patch:resolve@npm%3A1.22.4#~builtin<compat/resolve>::version=1.22.4&hash=c3c19d"
+  version: 1.22.5
+  resolution: "resolve@patch:resolve@npm%3A1.22.5#~builtin<compat/resolve>::version=1.22.5&hash=c3c19d"
   dependencies:
     is-core-module: ^2.13.0
     path-parse: ^1.0.7
     supports-preserve-symlinks-flag: ^1.0.0
   bin:
     resolve: bin/resolve
-  checksum: c45f2545fdc4d21883861b032789e20aa67a2f2692f68da320cc84d5724cd02f2923766c5354b3210897e88f1a7b3d6d2c7c22faeead8eed7078e4c783a444bc
+  checksum: 8478df3911a3420450038b87aab4a6c66b91461035d901cd794076b46adfbf157fcfc8e83e3d0ef41a5956ce72ae166c33bd78432d6b41d43ee473b05c51cb32
   languageName: node
   linkType: hard
 
@@ -10649,11 +10661,11 @@ __metadata:
   linkType: hard
 
 "ts-api-utils@npm:^1.0.1":
-  version: 1.0.2
-  resolution: "ts-api-utils@npm:1.0.2"
+  version: 1.0.3
+  resolution: "ts-api-utils@npm:1.0.3"
   peerDependencies:
     typescript: ">=4.2.0"
-  checksum: 6375e12ba90b6cbe73f564405248da14c52aa44b62b386e1cbbb1da2640265dd33e99d3e019688dffa874e365cf596b161ccd49351e90638be825c2639697640
+  checksum: 441cc4489d65fd515ae6b0f4eb8690057add6f3b6a63a36073753547fb6ce0c9ea0e0530220a0b282b0eec535f52c4dfc315d35f8a4c9a91c0def0707a714ca6
   languageName: node
   linkType: hard
 
@@ -11093,8 +11105,8 @@ __metadata:
   linkType: hard
 
 "vuetify@npm:^3.1.1, vuetify@npm:^3.3.14, vuetify@npm:^3.3.3":
-  version: 3.3.15
-  resolution: "vuetify@npm:3.3.15"
+  version: 3.3.16
+  resolution: "vuetify@npm:3.3.16"
   peerDependencies:
     typescript: ">=4.7"
     vite-plugin-vuetify: ^1.0.0-alpha.12
@@ -11110,7 +11122,7 @@ __metadata:
       optional: true
     webpack-plugin-vuetify:
       optional: true
-  checksum: b2e2d63bc4ed3cf249bdaa3f20cbcb9625bfa6fcaed4108bedde803b2b60a2fc5c764105d3513b3c0e8ecbcd4289a642a8fa0b8fd9baae8112865b3360b339ce
+  checksum: 2ffd5b8d399b6fb7e4ab45c314c6a5f8940879f059a112092090fd7ebb8bafb7873c583f94e99795e0d102bfe4e924fdec57f40fda1014452bba262e1c0886e3
   languageName: node
   linkType: hard
 
@@ -11382,9 +11394,9 @@ __metadata:
   linkType: hard
 
 "whatwg-fetch@npm:^3.6.2":
-  version: 3.6.18
-  resolution: "whatwg-fetch@npm:3.6.18"
-  checksum: 72fd318a00fd9031f7f5b28bfe30e458ca5e6ebc9b3de6e03edf810f455bca0ec954035bd9f1b5f9e6a82bbdc3fbba59b14bee24c039460c8a75f8f990ebe0b1
+  version: 3.6.19
+  resolution: "whatwg-fetch@npm:3.6.19"
+  checksum: 2896bc9ca867ea514392c73e2a272f65d5c4916248fe0837a9df5b1b92f247047bc76cf7c29c28a01ac6c5fb4314021d2718958c8a08292a96d56f72b2f56806
   languageName: node
   linkType: hard
 
@@ -11532,8 +11544,8 @@ __metadata:
   linkType: hard
 
 "ws@npm:>=8.7.0, ws@npm:^8.13.0, ws@npm:^8.2.3":
-  version: 8.14.0
-  resolution: "ws@npm:8.14.0"
+  version: 8.14.1
+  resolution: "ws@npm:8.14.1"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ">=5.0.2"
@@ -11542,7 +11554,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: dd91d055396c42552d8e2d26a0ab10221e73ca356de3db9109e337b8d9df216a0a308ace46a5e0520ed18ffcae3f54c2fa45a96711f94a063c816ef13a30b700
+  checksum: 9e310be2b0ff69e1f87d8c6d093ecd17a1ed4c37f281d17c35e8c30e2bd116401775b3d503249651374e6e0e1e9905db62fff096b694371c77561aee06bc3466
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR aims to resolve #160 (with the exception of the moon shader, which isn't yet implemented). Getting the setup as we wanted there required manipulating the order in which things are drawn in the WWT render loop. I had to do a couple of "don't try this at home" things to make this work:

* In order to modify the order in which things are drawn in the render loop, I needed to modify the `renderOneFrame` method of the `WWTControl`. This method accesses the `TileCache` class, which is internal and not exported by the engine module. (Note that previously we've just been shimming in things that _are_ exported from the JS module, but not exposed to TypeScript). Doing this requires a small change to the package's `index.js` file, which is the purpose of the `patch.sh` script.
* The way annotations are drawn, it's really not possible to have multiple annotation layers. Basically, each annotation is broken down into its graphical primitives, and those primitives are added to static lists in the annotation base class, which are then drawn all together by the WebGL renderer. In order to get around this, I basically made a second annotation class, with the same functionality but now with different static members. This second class is then drawn in a different place in the render loop.

Ultimately, we should think about which of these things seem like things we might want add upstream in WWT, and which are really specific to this particular case.
