### PR TITLE
Update location selector and add to eclipse mini

### DIFF
--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -75,6 +75,7 @@
               @place="(place: typeof places[number]) => updateLocation(place.name)"
               :map-options="mapOptions"
               :places="places"
+              :initial-place="places.find(p => p.name === 'Albuquerque, NM')"
               :place-circle-options="placeCircleOptions"
               :selected-circle-options="selectedCircleOptions"
               :selectable="false"
@@ -87,6 +88,7 @@
               <location-selector
                 :model-value="locationDeg"
                 @update:modelValue="updateLocationFromMap"
+                :selected-circle-options="selectedCircleOptions"
               ></location-selector>
             </span>
           </div>

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -73,6 +73,7 @@
             <location-selector
               v-if="learnerPath == 'Discover'"
               @place="(place: typeof places[number]) => updateLocation(place.name)"
+              :detect-location="false"
               :map-options="mapOptions"
               :places="places"
               :initial-place="places.find(p => p.name === 'Albuquerque, NM')"

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -70,8 +70,8 @@
         <div id="map-holder">
           <span id="title">What will the eclipse look like here?</span>
           <div id="map-container-map">
-            <span v-if="learnerPath=='Discover'">
             <location-selector
+              v-if="learnerPath == 'Discover'"
               @place="(place: typeof places[number]) => updateLocation(place.name)"
               :map-options="mapOptions"
               :places="places"
@@ -80,17 +80,15 @@
               :selected-circle-options="selectedCircleOptions"
               :selectable="false"
             ></location-selector>
-            </span>
             <span v-if="learnerPath=='Answer'">
               Show a map with a possible eclipse paths
             </span>
-            <span v-if="learnerPath=='Explore'">
-              <location-selector
-                :model-value="locationDeg"
-                @update:modelValue="updateLocationFromMap"
-                :selected-circle-options="selectedCircleOptions"
-              ></location-selector>
-            </span>
+            <location-selector
+              v-if="learnerPath == 'Explore'"
+              :model-value="locationDeg"
+              @update:modelValue="updateLocationFromMap"
+              :selected-circle-options="selectedCircleOptions"
+            ></location-selector>
           </div>
         </div>
         
@@ -2000,7 +1998,8 @@ video {
       }
       
       #map-container-map {
-        width: 100%;
+        height: 300px;
+        width: 450px;
         aspect-ratio: 2 / 1;
         background-color: cornsilk;
         

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -73,6 +73,7 @@
             <location-selector
               v-if="learnerPath == 'Discover'"
               ref="citySelector"
+              :model-value="locationDeg"
               @place="(place: typeof places[number]) => updateLocation(place.name)"
               :detect-location="false"
               :map-options="mapOptions"
@@ -120,7 +121,7 @@
           <div id="location-time-display">
             <div id="location-display" class="ltd-container">
               <p class="ltd-label">View for:</p>
-              <p class="ltd-value">{{ selectedLocation }}</p>
+              <p class="ltd-value">{{ selectedLocationText }}</p>
             </div>
             <div id="time-display" class="ltd-container">
               <p class="ltd-label">Time:</p>
@@ -982,6 +983,18 @@ export default defineComponent({
           latitudeRad: D2R * value.latitudeDeg,
           longitudeRad: D2R * value.longitudeDeg
         };
+      }
+    },
+
+    selectedLocationText(): string {
+      if (this.selectedLocation !== 'User Selected') {
+        return this.selectedLocation;
+      } else {
+        const ns = this.locationDeg.latitudeDeg >= 0 ? 'N' : 'S';
+        const ew = this.locationDeg.longitudeDeg >= 0 ? 'E' : 'W';
+        const lat = Math.abs(this.locationDeg.latitudeDeg).toFixed(3);
+        const lon = Math.abs(this.locationDeg.longitudeDeg).toFixed(3);
+        return `${lat}° ${ns}, ${lon}° ${ew}`;
       }
     }
   },

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -72,11 +72,12 @@
           <div id="map-container-map">
             <location-selector
               v-if="learnerPath == 'Discover'"
+              ref="citySelector"
               @place="(place: typeof places[number]) => updateLocation(place.name)"
               :detect-location="false"
               :map-options="mapOptions"
               :places="places"
-              :initial-place="places.find(p => p.name === 'Albuquerque, NM')"
+              :initial-place="places.find(p => p.name === selectedLocation)"
               :place-circle-options="placeCircleOptions"
               :selected-circle-options="selectedCircleOptions"
               :selectable="false"
@@ -88,6 +89,7 @@
               v-if="learnerPath == 'Explore'"
               :model-value="locationDeg"
               @update:modelValue="updateLocationFromMap"
+              :detect-location="false"
               :selected-circle-options="selectedCircleOptions"
             ></location-selector>
           </div>
@@ -1081,6 +1083,18 @@ export default defineComponent({
         longitudeRad: D2R * location.longitudeDeg,
         eclipseFracion: null
       };
+
+      const citySelector = this.$refs.citySelector;
+      // There's got to be a way to export the component data/method definitions
+      // but that's a problem for another day
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      citySelector?.onMapSelect({
+        latlng: {
+          lat: location.latitudeDeg,
+          lng: location.latitudeDeg
+        }
+      });
 
     },
 

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -72,20 +72,22 @@
           <div id="map-container-map">
             <span v-if="learnerPath=='Discover'">
             <location-selector
-              :model-value="locationDeg"
-              @update:modelValue="updateLocationFromMap"
               @place="(place: typeof places[number]) => updateLocation(place.name)"
               :map-options="mapOptions"
               :places="places"
               :place-circle-options="placeCircleOptions"
               :selected-circle-options="selectedCircleOptions"
+              :selectable="false"
             ></location-selector>
             </span>
             <span v-if="learnerPath=='Answer'">
               Show a map with a possible eclipse paths
             </span>
             <span v-if="learnerPath=='Explore'">
-              Show a map with a user selected location
+              <location-selector
+                :model-value="locationDeg"
+                @update:modelValue="updateLocationFromMap"
+              ></location-selector>
             </span>
           </div>
         </div>

--- a/common/src/components/LocationSelector.vue
+++ b/common/src/components/LocationSelector.vue
@@ -76,6 +76,14 @@ export default defineComponent({
         };
       }
     },
+    placeSelectable: {
+      type: Boolean,
+      default: true
+    },
+    selectable: {
+      type: Boolean,
+      default: true
+    },
     selectedCircleOptions: {
       type: Object as PropType<Record<string,any>>,
       default() {
@@ -197,9 +205,11 @@ export default defineComponent({
           circle.openTooltip([place.latitudeDeg, place.longitudeDeg]);
         });
 
-        circle.on('click', () => {
-          this.onPlaceSelect(this.places[index]);
-        });
+        if (this.placeSelectable) {
+          circle.on('click', () => {
+            this.onPlaceSelect(this.places[index]);
+          });
+        }
 
         circle.on('mouseout', () => {
           this.hoveredPlace = null;
@@ -209,7 +219,9 @@ export default defineComponent({
       });
 
       map.doubleClickZoom.disable();
-      map.on('dblclick', this.onMapSelect);
+      if (this.selectable) {
+        map.on('dblclick', this.onMapSelect);
+      }
       this.map = map;
     },
 

--- a/common/src/components/LocationSelector.vue
+++ b/common/src/components/LocationSelector.vue
@@ -59,6 +59,10 @@ export default defineComponent({
         };
       }
     },
+    initialPlace: {
+      type: Object as PropType<Place>,
+      default: null
+    },
     places: {
       type: Array as PropType<Place[]>,
       default() {
@@ -98,7 +102,9 @@ export default defineComponent({
   },
 
   mounted() {
-    console.log(this);
+    if (this.initialPlace) {
+      this.selectedPlace = this.initialPlace;
+    }
     if (this.detectLocation) {
       this.getLocation(true);
     }
@@ -233,7 +239,6 @@ export default defineComponent({
       if (this.map) {
         this.selectedCircle?.remove();
         this.selectedCircle = this.circleForSelection();
-        console.log(this.selectedCircle);
         if (this.selectedCircle) {
           this.selectedCircle.addTo(this.map as Map); // Not sure why, but TS is cranky w/o the Map cast
         }

--- a/common/src/components/LocationSelector.vue
+++ b/common/src/components/LocationSelector.vue
@@ -45,7 +45,7 @@ import { VCard } from "vuetify/components/VCard";
 import { VBtn } from "vuetify/components/VBtn";
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faLocationPin } from "@fortawesome/free-solid-svg-icons";
-import L, { LeafletMouseEvent, Map } from "leaflet";
+import L, { LeafletMouseEvent, Map, TileLayerOptions } from "leaflet";
 import "leaflet/dist/leaflet.css";
 import _Notifications from "@kyvg/vue3-notification";
 import { defineComponent, PropType } from "vue";
@@ -57,6 +57,10 @@ export type LocationDeg = {
   longitudeDeg: number;
   latitudeDeg: number;
 };
+
+interface MapOptions extends TileLayerOptions {
+  templateUrl: string;
+}
 
 export default defineComponent({
 
@@ -78,6 +82,18 @@ export default defineComponent({
         return {
           latitudeDeg: 42.3814,
           longitudeDeg: -71.1281
+        };
+      }
+    },
+    mapOptions: {
+      type: Object as PropType<MapOptions>,
+      default() {
+        return {
+          templateUrl: 'https://{s}.google.com/vt/lyrs=p&x={x}&y={y}&z={z}',
+          maxZoom: 20,
+          subdomains:['mt0','mt1','mt2','mt3'],
+          attribution: `&copy <a href="https://www.google.com/maps">Google Maps</a>`,
+          className: 'map-tiles'
         };
       }
     }
@@ -155,13 +171,7 @@ export default defineComponent({
     setup() {
       const map = L.map("map-container").setView([this.modelValue.latitudeDeg, this.modelValue.longitudeDeg], 4);
       
-      L.tileLayer('https://{s}.google.com/vt/lyrs=p&x={x}&y={y}&z={z}',{
-        maxZoom: 20,
-        subdomains:['mt0','mt1','mt2','mt3'],
-        attribution: `&copy <a href="https://www.google.com/maps">Google Maps</a>`,
-        className: 'map-tiles'
-      }).addTo(map);
-
+      L.tileLayer(this.mapOptions.templateUrl, this.mapOptions).addTo(map);
       this.circle = this.circleForLocation(this.modelValue).addTo(map);
 
       map.doubleClickZoom.disable();

--- a/common/src/components/LocationSelector.vue
+++ b/common/src/components/LocationSelector.vue
@@ -24,7 +24,6 @@ interface Place extends LocationDeg {
   radius?: number;
   name?: string;
 }
-
 export default defineComponent({
 
   emits: ["place", "update:modelValue", "error"],
@@ -196,7 +195,6 @@ export default defineComponent({
     },
 
     setup() {
-      console.log("setup");
       const map = L.map("map-container").setView([this.modelValue.latitudeDeg, this.modelValue.longitudeDeg], 4);
       
       const options = { minZoom: 1, maxZoom: 20, ...this.mapOptions };
@@ -269,16 +267,9 @@ export default defineComponent({
 </script>
 
 <style lang="less">
-.location-selector {
-  align-items: center;
-  margin: auto;
-  width: 70vw;
-  height: fit-content;
-}
-
 #map-container {
-  width: 60vw;
-  height: 70vh;
+  height: 100%;
+  width: 100%;
   margin: auto;
   padding: 5px 0px;
   border-radius: 5px;

--- a/common/src/components/LocationSelector.vue
+++ b/common/src/components/LocationSelector.vue
@@ -18,8 +18,8 @@ interface MapOptions extends TileLayerOptions {
 }
 
 interface Place extends LocationDeg { 
-  color?: Color;
-  fillColor?: Color;
+  color?: string;
+  fillColor?: string;
   fillOpacity?: number;
   radius?: number;
   name?: string;
@@ -64,7 +64,7 @@ export default defineComponent({
       }
     },
     placeCircleOptions: {
-      type: Object as Record<string, any>,
+      type: Object as PropType<Record<string, any>>,
       default() {
         return {
           color: "#0000FF",
@@ -75,7 +75,7 @@ export default defineComponent({
       }
     },
     selectedCircleOptions: {
-      type: Object as Record<string,any>,
+      type: Object as PropType<Record<string,any>>,
       default() {
         return {
           color: "#FF0000",
@@ -143,7 +143,7 @@ export default defineComponent({
       return this.circleForLocation(this.modelValue, this.selectedCircleOptions);
     },
 
-    circleForPlace(place): L.Circle {
+    circleForPlace(place: Place): L.Circle {
       return this.circleForLocation(place, this.placeCircleOptions);
     },
 
@@ -166,9 +166,12 @@ export default defineComponent({
       this.placeCircles = this.places.map(place => this.circleForPlace(place));
       this.placeCircles.forEach((circle, index) => {
         circle.on('hover', () => {
-          circle.openTooltip(this.places[index]);
+          const place = this.places[index];
+          circle.openTooltip([place.latitudeDeg, place.longitudeDeg]);
         });
-        if (this.places[index].name) {
+
+        const name = this.places[index].name;
+        if (name) {
           circle.bindTooltip(name);
         }
         circle.addTo(map);
@@ -186,7 +189,7 @@ export default defineComponent({
     updateCircle() {
       if (this.map) {
         this.selectedCircle?.remove();
-        this.selectedCircle = this.circleForLocation(this.modelValue).addTo(this.map as Map); // Not sure why, but TS is cranky w/o the Map cast
+        this.selectedCircle = this.circleForSelection().addTo(this.map as Map); // Not sure why, but TS is cranky w/o the Map cast
       }
     }
 

--- a/common/src/components/LocationSelector.vue
+++ b/common/src/components/LocationSelector.vue
@@ -6,7 +6,7 @@
 import L, { LeafletMouseEvent, Map, TileLayerOptions } from "leaflet";
 import "leaflet/dist/leaflet.css";
 import { notify } from "@kyvg/vue3-notification";
-import { defineComponent, toRaw, PropType } from "vue";
+import { defineComponent, PropType } from "vue";
 
 export interface LocationDeg {
   longitudeDeg: number;
@@ -188,6 +188,7 @@ export default defineComponent({
       const options = { minZoom: 1, maxZoom: 20, ...this.mapOptions };
       L.tileLayer(this.mapOptions.templateUrl, options).addTo(map);
       this.selectedCircle = this.circleForSelection();
+      this.selectedCircle?.addTo(map);
       this.placeCircles = this.places.map(place => this.circleForPlace(place));
       this.placeCircles.forEach((circle, index) => {
         circle.on('mouseover', () => {
@@ -220,6 +221,7 @@ export default defineComponent({
       if (this.map) {
         this.selectedCircle?.remove();
         this.selectedCircle = this.circleForSelection();
+        console.log(this.selectedCircle);
         if (this.selectedCircle) {
           this.selectedCircle.addTo(this.map as Map); // Not sure why, but TS is cranky w/o the Map cast
         }

--- a/common/src/components/LocationSelector.vue
+++ b/common/src/components/LocationSelector.vue
@@ -72,6 +72,7 @@ export default defineComponent({
 
   mounted() {
     this.getLocation(true);
+    this.setup();
   },
 
   data() {
@@ -137,7 +138,8 @@ export default defineComponent({
     setup() {
       const map = L.map("map-container").setView([this.modelValue.latitudeDeg, this.modelValue.longitudeDeg], 4);
       
-      L.tileLayer(this.mapOptions.templateUrl, this.mapOptions).addTo(map);
+      const options = { minZoom: 1, maxZoom: 20, ...this.mapOptions };
+      L.tileLayer(this.mapOptions.templateUrl, options).addTo(map);
       this.circle = this.circleForLocation(this.modelValue).addTo(map);
 
       map.doubleClickZoom.disable();

--- a/common/src/components/LocationSelector.vue
+++ b/common/src/components/LocationSelector.vue
@@ -1,46 +1,20 @@
 <template>
-  <v-dialog
-    v-model="show"
-    class="location-selector-dialog"
-  >
-    <!-- TODO: What should the real types here be?
-              We don't need them so it doesn't matter,
-              but would be good to know.
-    -->
-    <template v-slot:activator>
-      <slot
-        name="activator"
-        :open="open"
-      >
-        <icon-button
-          v-model="show"
-          :color="activatorColor"
-          fa-icon="location-pin"
-          class="map-icon"
-          tooltip-text="Select location"
-          tooltip-location="bottom"
-          tooltip-offset="5px"
-        ></icon-button>
-      </slot>
-    </template>
-    <v-card class="location-selector">
-      <div class="text-center">
-        Move around the map and double-click to change location
-      </div>
-      <v-btn
-        @click="getLocation"
-        @keyup.enter="getLocation"
-      >
-        Use My Location
-      </v-btn>
-      <div class="text-center red--text">{{ locationErrorMessage }}</div>
-      <div id="map-container"></div>
-    </v-card>
-  </v-dialog>
+  <v-card class="location-selector">
+    <div class="text-center">
+      Move around the map and double-click to change location
+    </div>
+    <v-btn
+      @click="getLocation"
+      @keyup.enter="getLocation"
+    >
+      Use My Location
+    </v-btn>
+    <div class="text-center red--text">{{ locationErrorMessage }}</div>
+    <div id="map-container"></div>
+  </v-card>
 </template>
 
 <script lang="ts">
-import { VDialog } from "vuetify/components/VDialog";
 import { VCard } from "vuetify/components/VCard";
 import { VBtn } from "vuetify/components/VBtn";
 import { library } from "@fortawesome/fontawesome-svg-core";
@@ -49,7 +23,6 @@ import L, { LeafletMouseEvent, Map, TileLayerOptions } from "leaflet";
 import "leaflet/dist/leaflet.css";
 import _Notifications from "@kyvg/vue3-notification";
 import { defineComponent, PropType } from "vue";
-import IconButton from "./IconButton.vue";
 
 library.add(faLocationPin);
 
@@ -67,8 +40,6 @@ export default defineComponent({
   components: {
     'v-btn': VBtn,
     'v-card': VCard,
-    'v-dialog': VDialog,
-    'icon-button': IconButton
   },
 
   props: {
@@ -107,16 +78,11 @@ export default defineComponent({
     return {
       circle: null as L.Circle | null,
       map: null as Map | null,
-      locationErrorMessage: "",
-      show: false
+      locationErrorMessage: ""
     };
   },
 
   methods: {
-
-    open() {
-      this.show = true;
-    },
 
     getLocation(startup=false) {
       const options = { timeout: 10000, enableHighAccuracy: true };
@@ -196,45 +162,24 @@ export default defineComponent({
     modelValue() {
       this.updateCircle();
     },
-
-    show(show: boolean) {
-      if (show) {
-        this.locationErrorMessage = "";
-        this.$nextTick(() => {
-          this.setup();
-        });
-      } else {
-        this.map?.remove();
-        this.map = null;
-        this.circle = null;
-      }
-    }
   }
 
 });
 </script>
 
 <style lang="less">
-.location-selector-dialog {
-  
-  .v-overlay__content {
-    width: fit-content !important;
-  }
+.location-selector {
+  align-items: center;
+  margin: auto;
+  width: 70vw;
+  height: fit-content;
+}
 
-  .location-selector {
-    align-items: center;
-    margin: auto;
-    width: 70vw;
-    height: fit-content;
-  }
-
-  #map-container {
-    width: 60vw;
-    height: 70vh;
-    margin: auto;
-    padding: 5px 0px;
-    border-radius: 5px;
-  }
-
+#map-container {
+  width: 60vw;
+  height: 70vh;
+  margin: auto;
+  padding: 5px 0px;
+  border-radius: 5px;
 }
 </style>

--- a/common/src/components/LocationSelector.vue
+++ b/common/src/components/LocationSelector.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="map-container"></div>
+  <div class="map-container"></div>
 </template>
 
 <script lang="ts">
@@ -195,12 +195,12 @@ export default defineComponent({
     },
 
     setup() {
-      const map = L.map("map-container").setView([this.modelValue.latitudeDeg, this.modelValue.longitudeDeg], 4);
+      const mapContainer = this.$el as HTMLDivElement;
+      const map = L.map(mapContainer).setView([this.modelValue.latitudeDeg, this.modelValue.longitudeDeg], 4);
       
       const options = { minZoom: 1, maxZoom: 20, ...this.mapOptions };
       L.tileLayer(this.mapOptions.templateUrl, options).addTo(map);
-      this.selectedCircle = this.circleForSelection();
-      this.selectedCircle?.addTo(map);
+
       this.placeCircles = this.places.map(place => this.circleForPlace(place));
       this.placeCircles.forEach((circle, index) => {
         circle.on('mouseover', () => {
@@ -221,6 +221,9 @@ export default defineComponent({
 
         circle.addTo(map);
       });
+
+      this.selectedCircle = this.circleForSelection();
+      this.selectedCircle?.addTo(map);
 
       map.doubleClickZoom.disable();
       if (this.selectable) {
@@ -267,7 +270,7 @@ export default defineComponent({
 </script>
 
 <style lang="less">
-#map-container {
+.map-container {
   height: 100%;
   width: 100%;
   margin: auto;


### PR DESCRIPTION
This PR updates the location selector with some additional functionality:
* Allow changing which map tiles are used, and the general map settings
* The ability to add places of interest, which can then be selected in the map
* Toggle whether or not general location selection is possible
* Specify the options for place and selection circles

In order to make the component more flexible, it's no longer in a dialog by default - it's easy enough to add that in the parent component.

Additionally, this PR adds two location selectors to the eclipse mini - one for our set of specified places, and another for the user selection. (Note that if we wanted to, the new functionality allows doing both of these things in one map). The settings for the map circles are specified in the eclipse mini. I think they're pretty easy to understand, but let me know if there are any questions.