### PR TITLE
Allow sharing location via URL

### DIFF
--- a/annular-eclipse-2023/package.json
+++ b/annular-eclipse-2023/package.json
@@ -5,6 +5,7 @@
     "@fortawesome/fontawesome-svg-core": "^6.4.2",
     "@fortawesome/free-solid-svg-icons": "^6.4.2",
     "@fortawesome/vue-fontawesome": "^3.0.3",
+    "@kyvg/vue3-notification": "^3.0.2",
     "@minids/common": "workspace:0.0.0",
     "vue": "^3.3.4",
     "vuetify": "^3.3.14",

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -145,7 +145,18 @@
             </div>
             
           </div>
-          <!-- <div id="main-guided-contols" class="controls"></div> -->
+
+          <div v-if="selectedLocation === 'User Selected'">
+            <icon-button
+              id="share"
+              fa-icon="share-nodes"
+              :color="accentColor"
+              background-color="transparent"
+              :box-shadow="false"
+              @activate="copyShareURL"
+            ></icon-button>
+          </div>
+          
         </div>
       </v-col>
     </v-row>
@@ -548,6 +559,8 @@
         </v-window>
       </v-card>
     </v-dialog>
+
+  <notifications group="copy-url" position="top right" />
   </div>
 </v-app>
 </template>
@@ -1369,6 +1382,26 @@ export default defineComponent({
       this.$nextTick(() => {
         this.updateGuidedContentHeight();
       });
+    },
+
+    copyShareURL() {
+      const url = `${window.location.origin}?lat=${this.locationDeg.latitudeDeg}&lon=${this.locationDeg.longitudeDeg}`;
+      navigator.clipboard
+        .writeText(url)
+        .then(() =>
+          this.$notify({
+            group: "copy-url",
+            type: "success",
+            text: "URL successfully copied"
+          })
+        )
+        .catch((_err) =>
+          this.$notify({
+            group: "copy-url",
+            type: "error",
+            text: "Failed to copy URL"
+          })
+        );
     }
 
   },
@@ -2131,6 +2164,8 @@ video {
   }
 }
 
-
-
+#share-button {
+  margin: auto;
+  width: 2em;
+}
 </style>

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -827,6 +827,14 @@ export default defineComponent({
         longitudeDeg: R2D * pl.longitudeRad
       };
     });
+
+    const searchParams = new URLSearchParams(window.location.search);
+    const lat = parseFloat(searchParams.get("lat") ?? "");
+    const lon = parseFloat(searchParams.get("lon") ?? "");
+    if (lat && lon) {
+      this.selectedLocation = "User Selected";
+      this.locationDeg = { latitudeDeg: lat, longitudeDeg: lon };
+    }
   },
 
   mounted() {

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -32,31 +32,36 @@
           <icon-button
             fa-icon="question"
             :color="accentColor"
+            :focus-color="accentColor"
             tooltip-location="start"
             @activate="() => { inIntro=true; introSlide = 2 }"
           ></icon-button>
           <icon-button
-            :v-model="learnerPath == 'Discover'"
+            :model-value="learnerPath == 'Discover'"
             fa-icon="rocket"
             :color="accentColor"
+            :focus-color="accentColor"
             @activate="() => { learnerPath = 'Discover'}"
           ></icon-button>
           <icon-button
-            :v-model="learnerPath == 'Answer'"
+            :model-value="learnerPath == 'Answer'"
             fa-icon="puzzle-piece"
             :color="accentColor"
+            :focus-color="accentColor"
             @activate="() => { learnerPath = 'Answer'}"
           ></icon-button>   
           <icon-button
-            :v-model="learnerPath == 'Explore'" 
+            :model-value="learnerPath == 'Explore'" 
             fa-icon="location-dot"
             :color="accentColor"
+            :focus-color="accentColor"
             @activate="() => { learnerPath = 'Explore'}"
           ></icon-button>
           <icon-button
             v-model="showTextSheet"
             fa-icon="book-open"
             :color="accentColor"
+            :focus-color="accentColor"
             :tooltip-text="showTextSheet ? 'Hide Info' : 'Learn More'"
             tooltip-location="start"
           ></icon-button>
@@ -65,6 +70,7 @@
             v-model="showVideoSheet"
             fa-icon="video"
             :color="accentColor"
+            :focus-color="accentColor"
             tooltip-text="Watch video"
             tooltip-location="start"
           >
@@ -72,6 +78,7 @@
           <icon-button
             fa-icon="sun"
             :color="accentColor"
+            :focus-color="accentColor"
             tooltip-text="Center view on Sun"
             tooltip-location='top'
             @activate="() => trackSun()"
@@ -151,6 +158,7 @@
               id="share"
               fa-icon="share-nodes"
               :color="accentColor"
+              :focus-color="accentColor"
               background-color="transparent"
               :box-shadow="false"
               @activate="copyShareURL"

--- a/annular-eclipse-2023/src/main.ts
+++ b/annular-eclipse-2023/src/main.ts
@@ -13,6 +13,8 @@ import 'vue-slider-component/theme/default.css';
 import Datepicker from '@vuepic/vue-datepicker';
 import '@vuepic/vue-datepicker/dist/main.css';
 
+import Notifications from "@kyvg/vue3-notification";
+
 import vuetify from "../plugins/vuetify";
 
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
@@ -35,7 +37,8 @@ import {
   faPuzzlePiece,
   faLocationDot,
   faChevronUp,
-  faQuestion
+  faQuestion,
+  faShareNodes
 } from "@fortawesome/free-solid-svg-icons";
 
 library.add(faBookOpen);
@@ -53,6 +56,7 @@ library.add(faPuzzlePiece);
 library.add(faLocationDot);
 library.add(faChevronUp);
 library.add(faQuestion);
+library.add(faShareNodes);
 
 /** v-hide directive taken from https://www.ryansouthgate.com/2020/01/30/vue-js-v-hide-element-whilst-keeping-occupied-space/ */
 // Extract the function out, up here, so I'm not writing it twice
@@ -68,6 +72,7 @@ createApp(AnnularEclipse2023, {
   // Plugins
   .use(wwtPinia)
   .use(vuetify)
+  .use(Notifications)
 
   // Directives
   .directive(

--- a/yarn.lock
+++ b/yarn.lock
@@ -490,6 +490,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@kyvg/vue3-notification@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "@kyvg/vue3-notification@npm:3.0.2"
+  peerDependencies:
+    vue: ^3.0.0
+  checksum: c6dbd3550083d9448006b50624ebeb778b86bbd564d1957e0f501fa9ed77821180b8b7b5aa9d0e7a45b2bc439a242cbd7cff6173301f1a2c8f77d863ebfd1b57
+  languageName: node
+  linkType: hard
+
 "@leichtgewicht/ip-codec@npm:^2.0.1":
   version: 2.0.4
   resolution: "@leichtgewicht/ip-codec@npm:2.0.4"
@@ -511,6 +520,7 @@ __metadata:
     "@fortawesome/fontawesome-svg-core": ^6.4.2
     "@fortawesome/free-solid-svg-icons": ^6.4.2
     "@fortawesome/vue-fontawesome": ^3.0.3
+    "@kyvg/vue3-notification": ^3.0.2
     "@minids/common": "workspace:0.0.0"
     "@typescript-eslint/eslint-plugin": ^6.5.0
     "@typescript-eslint/parser": ^6.5.0


### PR DESCRIPTION
This PR resolves #172 by adding functionality that allows users to copy a URL to share their location. This URL will have `lat` and `lon` query parameters that the mini can then parse to set a starting location.

I added this into the mini as a share button that will display when the current location is user-selected (i.e. not one of our specified cities). Feel free to restyle/move/etc!