### PR TITLE
Eclipse text UI style updates 2

### DIFF
--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -72,6 +72,8 @@
                 fa-icon="rocket"
                 :color="accentColor"
                 :focus-color="accentColor"
+                :tooltip-text="'View eclipse from multiple locations'"
+                :tooltip-location="'bottom'"
                 @activate="() => { learnerPath = 'Explore'}"
               ></icon-button>
               <icon-button
@@ -79,6 +81,8 @@
                 fa-icon="puzzle-piece"
                 :color="accentColor"
                 :focus-color="accentColor"
+                :tooltip-text="'Identify eclipse path'"
+                :tooltip-location="'bottom'"
                 @activate="() => { learnerPath = 'Answer'}"
               ></icon-button>   
               <icon-button
@@ -86,6 +90,8 @@
                 fa-icon="location-dot"
                 :color="accentColor"
                 :focus-color="accentColor"
+                :tooltip-text="'Choose any viewing location'"
+                :tooltip-location="'bottom'"
                 @activate="() => { learnerPath = 'Choose'}"
               ></icon-button>
               <icon-button
@@ -94,7 +100,7 @@
                 :color="accentColor"
                 :focus-color="accentColor"
                 :tooltip-text="showTextSheet ? 'Hide Info' : 'Learn More'"
-                tooltip-location="start"
+                :tooltip-location="'bottom'"
               ></icon-button>
               <icon-button
                 v-model="showVideoSheet"
@@ -102,7 +108,7 @@
                 :color="accentColor"
                 :focus-color="accentColor"
                 tooltip-text="Watch video"
-                tooltip-location="start"
+                :tooltip-location="'bottom'"
               >
               </icon-button>
               <icon-button
@@ -110,7 +116,7 @@
                 :color="accentColor"
                 :focus-color="accentColor"
                 tooltip-text="Center view on Sun"
-                tooltip-location='top'
+                :tooltip-location="'bottom'"
                 @activate="() => trackSun()"
               >
               </icon-button>
@@ -118,7 +124,7 @@
                 fa-icon="question"
                 :color="accentColor"
                 :focus-color="accentColor"
-                tooltip-location="start"
+                :tooltip-location="'bottom'"
                 @activate="() => { inIntro=true; introSlide = 2 }"
               ></icon-button>
             </div>

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -5,137 +5,42 @@
 >
 
   <!-- Top content box with map, location, time, and option icons -->
-
-  <v-card id="guided-content-container">
-    <v-row id="top-row">
-      <v-col cols="1">
-        <div>
-          <font-awesome-icon
-            v-model="showGuidedContent"
-            size="lg"
-            class="ma-1"
-            :color="accentColor"
-            :icon="showGuidedContent ? `chevron-down` : `chevron-up`"
-            @click="() => {
-              console.log('showGuidedContent = ', showGuidedContent);
-              showGuidedContent = !showGuidedContent;
-              onResize();
-            }"
-            @keyup.enter="showGuidedContent = !showGuidedContent"
-            tabindex="0"
-            tooltip-location="start"
-          /> 
-        </div>
-      </v-col>
-      <v-col>
-        <div id="top-guided-content" class="guided-content">
-          <icon-button
-            fa-icon="question"
-            :color="accentColor"
-            :focus-color="accentColor"
-            tooltip-location="start"
-            @activate="() => { inIntro=true; introSlide = 2 }"
-            class="icon-wrapper top-icons"
-          ></icon-button>
-          <icon-button
-            :model-value="learnerPath == 'Explore'"
-            fa-icon="rocket"
-            :color="accentColor"
-            :focus-color="accentColor"
-            @activate="() => { learnerPath = 'Explore'}"
-          ></icon-button>
-          <icon-button
-            :model-value="learnerPath == 'Answer'"
-            fa-icon="puzzle-piece"
-            :color="accentColor"
-            :focus-color="accentColor"
-            @activate="() => { learnerPath = 'Answer'}"
-          ></icon-button>   
-          <icon-button
-            :model-value="learnerPath == 'Choose'" 
-            fa-icon="location-dot"
-            :color="accentColor"
-            :focus-color="accentColor"
-            @activate="() => { learnerPath = 'Choose'}"
-          ></icon-button>
-          <icon-button
-            v-model="showTextSheet"
-            fa-icon="book-open"
-            :color="accentColor"
-            :focus-color="accentColor"
-            :tooltip-text="showTextSheet ? 'Hide Info' : 'Learn More'"
-            tooltip-location="start"
-          ></icon-button>
-          
-          <icon-button
-            v-model="showVideoSheet"
-            fa-icon="video"
-            :color="accentColor"
-            :focus-color="accentColor"
-            tooltip-text="Watch video"
-            tooltip-location="start"
-          >
-          </icon-button>
-          <icon-button
-            fa-icon="sun"
-            :color="accentColor"
-            :focus-color="accentColor"
-            tooltip-text="Center view on Sun"
-            tooltip-location='top'
-            @activate="() => trackSun()"
-          >
-          </icon-button>
-        </div>
-      </v-col>
-    </v-row>
-    <v-row id="title-row">
-      <v-col>
-        What will the eclipse look like here?
-      </v-col>
-    </v-row>
-    <v-row v-if="showGuidedContent" id="bottom-guided-content">
-      <v-col :lg="4" :sm="6">
-        <div id="map-holder">
-          <div id="map-container-map">
-            <location-selector
-              v-if="learnerPath == 'Explore'"
-              :model-value="locationDeg"
-              @place="(place: typeof places[number]) => updateLocation(place.name)"
-              :detect-location="false"
-              :map-options="mapOptions"
-              :places="places"
-              :initial-place="places.find(p => p.name === 'selectedLocation')"
-              :place-circle-options="placeCircleOptions"
-              :selected-circle-options="selectedCircleOptions"
-              :selectable="false"
-            ></location-selector>
-
-            <span v-if="learnerPath=='Answer'">
-              <img alt="CosmicDS Logo" src="../../assets/EclipseMapPaths.png"/>
-            </span>
-
-            <location-selector
-              v-if="learnerPath == 'Choose'"
-              :model-value="locationDeg"
-              @update:modelValue="updateLocationFromMap"
-              :detect-location="false"
-              :selected-circle-options="selectedCircleOptions"
-            ></location-selector>
-          </div>
-        </div>
-      </v-col>
-      <v-col lg="4" sm="6">
-          <div id="bottom-center-content">
-            
+  <v-container id="guided-content-container" v-if="showGuidedContent">
+    <div id="close-guided-content-container">
+      <font-awesome-icon
+        v-model="showGuidedContent"
+        size="lg"
+        class="ma-1"
+        :color="accentColor"
+        :icon="`square-xmark`"
+        @click="() => {
+          console.log('showGuidedContent = ', showGuidedContent);
+          showGuidedContent = !showGuidedContent;
+          onResize();
+        }"
+        @keyup.enter="showGuidedContent = !showGuidedContent"
+        tabindex="0"
+        tooltip-location="start"
+      /> 
+    </div>
+    <v-row>
+      <v-col cols="6" id="non-map-container">
+        <v-row>
+          <v-col>
+            <span id="title">What will the eclipse look like here?</span>
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-col id="top-container-main-text">
             <!-- Learn Path -->
-            <div class="bottom-center-content-text" v-if="learnerPath=='Explore'">
+            <div class="instructions-text" v-if="learnerPath=='Explore'">
               <span id="description">
                 <p>Click a highlighted city to view the eclipse from that location.</p>
                 <p>Explore until you can identify which locations will see an annular eclipse</p>
               </span>
             </div>
             
-            <div class="bottom-center-content-text" v-if="learnerPath=='Answer'">
+            <div class="instructions-text" v-if="learnerPath=='Answer'">
               <span id="description">
                 <p>Once you've looked at enough locations, click the path that will expereience an annular eclipse</p>
                 <p>If you are not sure, click <font-awesome-icon icon="rocket"></font-awesome-icon> to keep exploring</p>
@@ -143,7 +48,7 @@
             </div>
             
             <!-- Choose Path -->
-            <div class="bottom-center-content-text" v-if="learnerPath=='Choose'">
+            <div class="instructions-text" v-if="learnerPath=='Choose'">
               <p id="description">Click a location on the map to select any place you like.</p>
             </div>
             
@@ -157,23 +62,118 @@
                 <p class="ltd-value">{{selectedLocaledTimeDateString }}</p>
               </div>
             </div>
-            
-          </div>
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-col>
+            <div id="top-container-buttons">
+              <icon-button
+                fa-icon="question"
+                :color="accentColor"
+                :focus-color="accentColor"
+                tooltip-location="start"
+                @activate="() => { inIntro=true; introSlide = 2 }"
+              ></icon-button>
+              <icon-button
+                :model-value="learnerPath == 'Explore'"
+                fa-icon="rocket"
+                :color="accentColor"
+                :focus-color="accentColor"
+                @activate="() => { learnerPath = 'Explore'}"
+              ></icon-button>
+              <icon-button
+                :model-value="learnerPath == 'Answer'"
+                fa-icon="puzzle-piece"
+                :color="accentColor"
+                :focus-color="accentColor"
+                @activate="() => { learnerPath = 'Answer'}"
+              ></icon-button>   
+              <icon-button
+                :model-value="learnerPath == 'Choose'" 
+                fa-icon="location-dot"
+                :color="accentColor"
+                :focus-color="accentColor"
+                @activate="() => { learnerPath = 'Choose'}"
+              ></icon-button>
+              <icon-button
+                v-model="showTextSheet"
+                fa-icon="book-open"
+                :color="accentColor"
+                :focus-color="accentColor"
+                :tooltip-text="showTextSheet ? 'Hide Info' : 'Learn More'"
+                tooltip-location="start"
+              ></icon-button>
+              <icon-button
+                v-model="showVideoSheet"
+                fa-icon="video"
+                :color="accentColor"
+                :focus-color="accentColor"
+                tooltip-text="Watch video"
+                tooltip-location="start"
+              >
+              </icon-button>
+              <icon-button
+                fa-icon="sun"
+                :color="accentColor"
+                :focus-color="accentColor"
+                tooltip-text="Center view on Sun"
+                tooltip-location='top'
+                @activate="() => trackSun()"
+              >
+              </icon-button>
+            </div>
+          </v-col>
+        </v-row>
+      </v-col>
+      <v-col cols="6" id="map-column">
+        <div id="map-container" >
+          <location-selector
+            v-if="learnerPath == 'Explore'"
+            :model-value="locationDeg"
+            @place="(place: typeof places[number]) => updateLocation(place.name)"
+            :detect-location="false"
+            :map-options="mapOptions"
+            :places="places"
+            :initial-place="places.find(p => p.name === 'selectedLocation')"
+            :place-circle-options="placeCircleOptions"
+            :selected-circle-options="selectedCircleOptions"
+            :selectable="false"
+            class="leaflet-map"
+          ></location-selector>
 
-          <div v-if="selectedLocation === 'User Selected'">
-            <icon-button
-              id="share"
-              fa-icon="share-nodes"
-              :color="accentColor"
-              :focus-color="accentColor"
-              background-color="transparent"
-              :box-shadow="false"
-              @activate="copyShareURL"
-            ></icon-button>
-          </div>
+          <span v-if="learnerPath=='Answer'">
+            <img alt="CosmicDS Logo" src="../../assets/EclipseMapPaths.png"/>
+          </span>
+
+          <location-selector
+            v-if="learnerPath == 'Choose'"
+            :model-value="locationDeg"
+            @update:modelValue="updateLocationFromMap"
+            :detect-location="false"
+            :selected-circle-options="selectedCircleOptions"
+            class="leaflet-map"
+          ></location-selector>
+        </div>
       </v-col>
     </v-row>
-  </v-card>
+  </v-container>
+  <div v-if="!showGuidedContent" id="closed-top-container">
+    <font-awesome-icon
+      v-model="showGuidedContent"
+      size="lg"
+      class="ma-1"
+      :color="accentColor"
+      :icon="`gear`"
+      @click="() => {
+        console.log('showGuidedContent = ', showGuidedContent);
+        showGuidedContent = !showGuidedContent;
+        onResize();
+      }"
+      @keyup.enter="showGuidedContent = !showGuidedContent"
+      tabindex="0"
+      tooltip-location="start"
+    /> 
+  </div>
 
   <div
     id="main-content"
@@ -746,7 +746,7 @@ export default defineComponent({
       selectionProximity: 4,
       pointerMoveThreshold: 6,
       isPointerMoving: false,
-      pointerStartPosition: null as { x: number; y: number } | null,      
+      pointerStartPosition: null as { x: number; y: number } | null,  
 
       // Albuquerque, NM
       timeOfDay: { hours: annularEclipseTimeNMTZ.getHours(), minutes: annularEclipseTimeNMTZ.getMinutes(), seconds: annularEclipseTimeNMTZ.getSeconds() },
@@ -1624,7 +1624,8 @@ export default defineComponent({
             text: "Failed to copy URL"
           })
         );
-    }
+    },
+
 
   },
 
@@ -2265,44 +2266,59 @@ video {
 
 }
 
+#closed-top-container{
+  padding-block: 0.25em;
+  margin-left: 0.5em;
+}
+
 #guided-content-container {
-  --margin: 0px;
+  --top-content-max-height: 35%;
+  --map-max-height: 32vh; // Keep this about 3 smaller than above
+
+  max-height: var(--top-content-max-height);
+  --margin: 0.5em;
   position: relative;
-  top: 5px; 
   left: 0;
   width: calc(100% - 2*var(--margin));
-  height: fit-content; 
+  // height: fit-content; 
   margin: var(--margin);
-  padding-block: 0.5rem;
+  padding: 0.5rem;
   // pointer-events: none;
-  display: flex;
-  flex-direction: column;
+  position: relative;
+
   // justify-content: center;
   align-items: center;
   gap: 0.5rem;
   // border-bottom: 1px solid var(--accent-color);
   background-color: #272727;
   user-select: none;
+  border: solid 1px var(--accent-color);
   
   transition: height 0.5s ease-in-out;
 
   .v-row {
     margin: 0px;
+    padding: 0px;
   }
 
   .v-col {
+    margin: 0px;
     padding: 0px;
   }
 
   .leaflet-control-zoom-in,
   .leaflet-control-zoom-out {
-    width: 5em; 
-    height: 5em; 
-    font-size: 0.4em; 
+
+    @media (max-width: 750px){ //SMALL
+      width: 4em; 
+      // height: 5em; 
+      font-size: 0.4em; 
+    }
+
     background-color: #fff;
     border: 1px solid #ccc; 
     cursor: pointer; /* Change cursor on hover */
-}
+  } 
 
   .leaflet-touch {
     line-height: 5em;
@@ -2315,7 +2331,7 @@ video {
     width: 90%;
   }
 
-  #top-guided-content {
+  #top-container-buttons {
     // buttons
     display: flex;
     flex-direction: row;
@@ -2340,74 +2356,81 @@ video {
     }
   }
     
-}
-  #title-row {
+  #title {
     color: var(--accent-color);
     font-weight: bold;
     text-align: left;
+    padding-left: 1em;
 
     @media (max-width: 750px){ //SMALL
-      width: 95%;
       font-size: 0.8rem;
     }
 
     @media (min-width: 751px){ //LARGE
-      width: 70%;
       font-size: 1rem;
     }
   }
 
-  #bottom-guided-content {
+  #map-column {
     // map stuff
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
+    align-content: center;
     justify-content: center;
-
-    @media (max-width: 750px){ //SMALL
-      width: 95%;
-    }
-
-    @media (min-width: 751px){ //LARGE
-      width: 70%;
-      padding-bottom: 1.5em;
-    }
+    height: 95%;
+    width: 95%;
   
-    #map-holder {
-      // width: 90%;
+    #map-container {
       pointer-events: auto;
-      margin-inline: auto;
-      
+      height: 100%;
+      width: 100%;
 
+      @media (max-width: 550px){ //SMALL
+        font-size: 0.8rem;
+        aspect-ratio: 3/4; // need to set this to some reasonable value or you just get a tiny horizontal strip
+      }
+
+      @media (min-width: 551px){ //LARGE
+        font-size: 1rem;
+        aspect-ratio: 5/3; // need to set this to some reasonable value or you just get a tiny horizontal strip
+      }
+
+      max-height: var(--map-max-height); // this keeps map from spilling outside the top div for some window aspect ratios
       
-      #map-container-map {
-        aspect-ratio: 5 / 3;
-        background-color: cornsilk;
-        border-radius: 5px;
-        
-        span {
-          font-weight: bold;
-          color: black;
-          // wrap text
-          white-space: break-spaces;
-        }
+      .leaflet-map {
+        height: 100%;
+        width: 100%;
+      }
+      span {
+        color: black;
+        padding: 0;
+        margin: 0;
+      }
 
       img {
-        height: 170px;
+        width: 100%;
       }
-        
-      }
-      
     }
+  }
 
-    #bottom-center-content {
-      // text guidelines
-      .bottom-center-content-text {
-        color: white;
-        text-align: left;
-        line-height: 1.2em;
-        border: 1.5px solid var(--accent-color);
-        border-radius: 5px; 
+  #close-guided-content-container {
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 500;
+  }
+
+  #non-map-container {
+    padding-left: 0.5em;
+    padding-top: 0.5em;
+  }
+
+  #top-container-main-text {
+    // text guidelines
+    .instructions-text {
+      color: white;
+      text-align: left;
+      line-height: 1.2em;
+      border: 1.5px solid var(--accent-color);
+      border-radius: 5px; 
 
       @media (max-width: 750px) { // SMALL for screensize smaller than or equal to 750px
         font-size: 0.7em;
@@ -2423,7 +2446,7 @@ video {
           padding-bottom: 0.4em;
         }
       }
-  
+
       @media (min-width:751px) {  // LARGE for screensize greater than or equal to 751px
         font-size: 1em;
         margin: 1em;
@@ -2440,45 +2463,43 @@ video {
       }
     }
       
-      #location-time-display {
-        margin: 1em;
-        display: flex;
-        flex-direction: row;
+    #location-time-display {
+      margin: 1em;
+      display: flex;
+      flex-direction: row;
+      flex-grow: 1;
+      gap: 0.5rem;
+    
+      .ltd-container {
+        // display: block;
+        text-align: left;
+        background-color: aliceblue;
+        color: blue;
+        border-radius: 0.5em;
         flex-grow: 1;
-        gap: 0.5rem;
-      
-        .ltd-container {
-          // display: block;
+
+        @media (max-width: 750px){ //SMALL
+          padding-left: 0.5em;
+          padding-block: 0.4em;
+          margin-bottom: 0.3em;
+          font-size: 0.6em;
+        }
+
+        @media (min-width: 751px){ //LARGE
+          padding-left: 1em;
+          padding-block: 0.7em;
+          margin-bottom: 0.5em;
           text-align: left;
-          background-color: aliceblue;
-          color: blue;
-          border-radius: 0.5em;
-          flex-grow: 1;
-
-          @media (max-width: 750px){ //SMALL
-            padding-left: 0.5em;
-            padding-block: 0.4em;
-            margin-bottom: 0.3em;
-            font-size: 0.6em;
-          }
-
-          @media (min-width: 751px){ //LARGE
-            padding-left: 1em;
-            padding-block: 0.7em;
-            margin-bottom: 0.5em;
-            text-align: left;
-            font-size: 0.8em;
-          }
+          font-size: 0.8em;
         }
-        
-        .ltd-label {
-          font-weight: bold;
-        }
+      }
+      
+      .ltd-label {
+        font-weight: bold;
       }
     }
   }
-
-
+}
 
 
 #introduction-overlay {

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -200,12 +200,13 @@
     <WorldWideTelescope
       :wwt-namespace="wwtNamespace"
     ></WorldWideTelescope>
-    <v-tooltip
-        location="right"
-        :color="accentColor"
-        :style="cssVars"
-      >
-      <template v-slot:activator="{props}">
+    <div>
+      <v-tooltip
+          location="right"
+          :color="accentColor"
+          :style="cssVars"
+        >
+        <template v-slot:activator="{props}">
           <div 
             v-bind="props"
             id="viewer-mode-switch"
@@ -228,7 +229,19 @@
         </template>
         Switch to {{ viewerMode === 'SunScope' ? 'Horizon' : 'Eclipse Scope' }} View
       </v-tooltip>
-    
+      <div v-if="selectedLocation === 'User Selected'" id="share-button">
+        <icon-button
+          id="share"
+          fa-icon="share-nodes"
+          :color="accentColor"
+          :focus-color="accentColor"
+          background-color="transparent"
+          :box-shadow="false"
+          @activate="copyShareURL"
+        ></icon-button>
+      </div>
+    </div>
+     
     <v-overlay
       :model-value="showSplashScreen"
       absolute
@@ -1951,6 +1964,13 @@ body {
     color: var(--accent-color);
     background-color: black; 
   }
+}
+
+#share-button {
+  position: absolute;
+  top: 0.7rem;
+  right: 1rem;
+
 }
 
 .top-content {

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -1026,7 +1026,7 @@ export default defineComponent({
     cssVars() {
       return {
         '--accent-color': this.accentColor,
-        '--sky-color': this.skyColor,
+        '--sky-color': this.skyColorLight,
         '--app-content-height': this.showTextSheet ? '66%' : '100%',
         '--top-content-height': this.inIntro ? '0px' : (this.showGuidedContent? this.guidedContentHeight : this.guidedContentHeight),
       };

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -25,46 +25,59 @@
     </div>
     <v-row>
       <v-col cols="6" id="non-map-container">
-        <v-row>
+        <v-row id="title-row" class="non-map-row">
           <v-col>
-            <span id="title">What will the eclipse look like here?</span>
+            <div id="title">
+              <span v-if="learnerPath=='Explore'"
+                >Watch the eclipse
+              </span>
+              <span v-if="learnerPath=='Answer'"
+                >Identify the eclipse path
+              </span>
+              <span v-if="learnerPath=='Choose'"
+                >Choose any viewing location
+              </span>
+            </div>
           </v-col>
         </v-row>
-        <v-row>
+        <v-row id="instructions-row" class="non-map-row">
           <v-col id="top-container-main-text">
             <!-- Learn Path -->
             <div class="instructions-text" v-if="learnerPath=='Explore'">
-              <span id="description">
-                <p>Click a highlighted city to view the eclipse from that location.</p>
+              <span class="description">
+                <p>Click a highlighted city to view the eclipse from this location.</p>
                 <p>Explore until you can identify which locations will see an annular eclipse</p>
               </span>
             </div>
             
             <div class="instructions-text" v-if="learnerPath=='Answer'">
-              <span id="description">
-                <p>Once you've looked at enough locations, click the path that will expereience an annular eclipse</p>
-                <p>If you are not sure, click <font-awesome-icon icon="rocket"></font-awesome-icon> to keep exploring</p>
+              <span class="description">
+                <p>Once you have collected enough data to determine the annular eclipse path, click to select it.</p>
+                <p>If you are not sure, click <font-awesome-icon icon="rocket"></font-awesome-icon> to keep exploring.</p>
               </span>
             </div>
             
             <!-- Choose Path -->
             <div class="instructions-text" v-if="learnerPath=='Choose'">
-              <p id="description">Click a location on the map to select any place you like.</p>
+              <p class="description">Select any location you like by clicking on the map, and view the eclipse from your chosen spot.</p>
             </div>
-            
-            <div id="location-time-display">
+          </v-col>
+        </v-row>
+        <v-row id="location-time-row" class="non-map-row">
+          <v-col :lg="5">
               <div id="location-display" class="ltd-container">
                 <p class="ltd-label">View for:</p>
                 <p class="ltd-value">{{ selectedLocationText }}</p>
               </div>
+          </v-col>
+          <v-col>
               <div id="time-display" class="ltd-container">
                 <p class="ltd-label">Time:</p>
                 <p class="ltd-value">{{selectedLocaledTimeDateString }}</p>
               </div>
-            </div>
           </v-col>
         </v-row>
-        <v-row>
+        <v-row class="non-map-row">
           <v-col>
             <div id="top-container-buttons">
               <icon-button
@@ -213,7 +226,7 @@
           
           </div>
         </template>
-        Switch to {{ viewerMode === 'SunScope' ? 'Horizon' : 'Eclipse' }} View
+        Switch to {{ viewerMode === 'SunScope' ? 'Horizon' : 'Eclipse Scope' }} View
       </v-tooltip>
     
     <v-overlay
@@ -2023,6 +2036,24 @@ body {
     flex-direction: column;
     justify-content: flex-start;
 
+        
+    @media (max-width: 750px){ //SMALL
+      
+      .v-checkbox .v-selection-control {
+      height: 1.5em !important;
+      min-height: 1em !important;
+     }
+
+    }
+
+    @media (min-width: 751px){ //LARGE
+      .v-checkbox .v-selection-control {
+      height: 2em !important;
+      min-height: 1em !important;
+     }
+    }
+
+
     .v-btn {
       align-self: center;
       padding-left: 5px;
@@ -2278,6 +2309,10 @@ video {
   margin-left: 0.5em;
 }
 
+.v-container {
+  max-width: 100%;
+}
+
 #guided-content-container {
   --top-content-max-height: 35%;
   --map-max-height: 32vh; // Keep this about 3 smaller than above
@@ -2355,26 +2390,17 @@ video {
       }  
 
       &.active {
-        border: 1.5px solid var(--sky-color);
+        border: 2px solid var(--sky-color);
       }
 
     }
   }
-    
-  #title {
-    color: var(--accent-color);
-    font-weight: bold;
-    text-align: left;
+  
+  .non-map-row {
+    display: flex;
+    width: 95%;
     padding-left: 1em;
-
-    @media (max-width: 750px){ //SMALL
-      font-size: 0.8rem;
-    }
-
-    @media (min-width: 751px){ //LARGE
-      font-size: 1rem;
-    }
-  }
+  }  
 
   #map-column {
     // map stuff
@@ -2423,82 +2449,110 @@ video {
     z-index: 500;
   }
 
-  #non-map-container {
+  #non-map-container { // Keep content away from the x to close
     padding-left: 0.5em;
     padding-top: 0.5em;
   }
 
-  #top-container-main-text {
-    // text guidelines
-    .instructions-text {
-      color: white;
-      text-align: left;
-      line-height: 1.2em;
-      border: 1.5px solid var(--sky-color);
-      border-radius: 5px; 
+  #title-row {
+    color: var(--accent-color);
+    font-weight: bold;
+    text-align: left;
 
-      @media (max-width: 750px) { // SMALL for screensize smaller than or equal to 750px
-        font-size: 0.7em;
-        margin: 0.7em;
-        padding-inline: 0.7em;
-        padding-top: 0.7em;
-        padding-bottom: 0.3em;
-
-        p {
-          padding-bottom: 0.4em;
-        }
-      }
-
-      @media (min-width:751px) {  // LARGE for screensize greater than or equal to 751px
-        font-size: 1em;
-        margin: 1em;
-        padding-inline: 1em;
-        padding-top: 1em;
-        padding-bottom: 0.4em;
-
-        p {
-          padding-bottom: 0.6em;
-        }
-      }
+    @media (max-width: 750px){ //SMALL
+      font-size: 0.8rem;
     }
-      
-    #location-time-display {
-      margin: 1em;
+
+    @media (min-width: 751px){ //LARGE
+      font-size: 1rem;
+      margin-bottom: 0.2rem;
+    }
+  }
+
+  #instructions-row {
+    width: 95%;
+    min-height: 35%;
+    min-width: 95%;
+
+    #top-container-main-text {
       display: flex;
-      flex-direction: row;
-      flex-grow: 1;
-      gap: 0.5rem;
-    
-      .ltd-container {
-        // display: block;
+
+      .instructions-text {
+        color: white;
         text-align: left;
-        background-color: aliceblue;
-        color: blue;
-        border-radius: 0.5em;
-        flex-grow: 1;
+        border: 1.5px solid var(--sky-color);
+        border-radius: 5px; 
 
-        @media (max-width: 750px){ //SMALL
-          padding-left: 0.5em;
-          padding-block: 0.4em;
-          margin-bottom: 0.3em;
-          font-size: 0.6em;
+        @media (max-width: 750px) { // SMALL for screensize smaller than or equal to 750px
+          font-size: 0.75rem;
+          line-height: 1.2em;
+          margin: 0.75em;
+          padding-inline: 0.7em;
+          padding-top: 0.7em;
+          padding-bottom: 0.3em;
+
+          p {
+            padding-bottom: 0.4em;
+          }
         }
 
-        @media (min-width: 751px){ //LARGE
-          padding-left: 1em;
-          padding-block: 0.7em;
-          margin-bottom: 0.5em;
-          text-align: left;
-          font-size: 0.8em;
+        @media (min-width:751px) {  // LARGE for screensize greater than or equal to 751px
+          font-size: 0.9rem;
+          line-height: 1.3em;
+          margin-top: 0.5em;
+          padding-inline: 0.7em;
+          padding-top: 0.7em;
+          padding-bottom: 0.2em;
+
+          p {
+            padding-bottom: 0.5em;
+          }
+
         }
-      }
-      
-      .ltd-label {
-        font-weight: bold;
       }
     }
   }
+
+  #location-time-row {
+    width: 95%;
+    margin-block: 0.9em;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    flex-grow: 1;
+    gap: 0.5rem;
+  
+    .ltd-container {
+      // display: block;
+      text-align: left;
+      background-color: white;
+      color: blue;
+      border-radius: 0.5em;
+      flex-grow: 1;
+
+      @media (max-width: 750px){ //SMALL
+        padding-left: 0.5em;
+        padding-block: 0.4em;
+        margin-bottom: 0.3em;
+        font-size: 0.6em;
+      }
+
+      @media (min-width: 751px){ //LARGE
+        padding-left: 1em;
+        padding-block: 0.7em;
+        margin-bottom: 0.5em;
+        text-align: left;
+        font-size: 0.8em;
+      }
+    }
+    
+    .ltd-label {
+      font-weight: bold;
+    }
+  }
 }
+
+
 
 
 #introduction-overlay {

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -37,11 +37,11 @@
             @activate="() => { inIntro=true; introSlide = 2 }"
           ></icon-button>
           <icon-button
-            :model-value="learnerPath == 'Discover'"
+            :model-value="learnerPath == 'Explore'"
             fa-icon="rocket"
             :color="accentColor"
             :focus-color="accentColor"
-            @activate="() => { learnerPath = 'Discover'}"
+            @activate="() => { learnerPath = 'Explore'}"
           ></icon-button>
           <icon-button
             :model-value="learnerPath == 'Answer'"
@@ -51,11 +51,11 @@
             @activate="() => { learnerPath = 'Answer'}"
           ></icon-button>   
           <icon-button
-            :model-value="learnerPath == 'Explore'" 
+            :model-value="learnerPath == 'Choose'" 
             fa-icon="location-dot"
             :color="accentColor"
             :focus-color="accentColor"
-            @activate="() => { learnerPath = 'Explore'}"
+            @activate="() => { learnerPath = 'Choose'}"
           ></icon-button>
           <icon-button
             v-model="showTextSheet"
@@ -87,41 +87,43 @@
         </div>
       </v-col>
     </v-row>
-    <v-row>
-      <v-col>
-        <div v-if="showGuidedContent" id="bottom-guided-content">
-          <div id="map-holder">
-            <span id="title">What will the eclipse look like here?</span>
-            <div id="map-container-map">
-              <location-selector
-                v-if="learnerPath == 'Discover'"
-                :model-value="locationDeg"
-                @place="(place: typeof places[number]) => updateLocation(place.name)"
-                :detect-location="false"
-                :map-options="mapOptions"
-                :places="places"
-                :initial-place="places.find(p => p.name === 'selectedLocation')"
-                :place-circle-options="placeCircleOptions"
-                :selected-circle-options="selectedCircleOptions"
-                :selectable="false"
-              ></location-selector>
-              <span v-if="learnerPath=='Answer'">
-                <img alt="CosmicDS Logo" src="../../assets/EclipseMapPaths.png"/>
-              </span>
-              <location-selector
-                v-if="learnerPath == 'Explore'"
-                :model-value="locationDeg"
-                @update:modelValue="updateLocationFromMap"
-                :detect-location="false"
-                :selected-circle-options="selectedCircleOptions"
-              ></location-selector>
-            </div>
+    <v-row v-if="showGuidedContent" id="bottom-guided-content">
+      <v-col :lg="4" :sm="6">
+        <div id="map-holder">
+          <span id="title">What will the eclipse look like here?</span>
+          <div id="map-container-map">
+            <location-selector
+              v-if="learnerPath == 'Explore'"
+              :model-value="locationDeg"
+              @place="(place: typeof places[number]) => updateLocation(place.name)"
+              :detect-location="false"
+              :map-options="mapOptions"
+              :places="places"
+              :initial-place="places.find(p => p.name === 'selectedLocation')"
+              :place-circle-options="placeCircleOptions"
+              :selected-circle-options="selectedCircleOptions"
+              :selectable="false"
+            ></location-selector>
+
+            <span v-if="learnerPath=='Answer'">
+              <img alt="CosmicDS Logo" src="../../assets/EclipseMapPaths.png"/>
+            </span>
+
+            <location-selector
+              v-if="learnerPath == 'Choose'"
+              :model-value="locationDeg"
+              @update:modelValue="updateLocationFromMap"
+              :detect-location="false"
+              :selected-circle-options="selectedCircleOptions"
+            ></location-selector>
           </div>
-          
+        </div>
+      </v-col>
+      <v-col lg="4" sm="6">
           <div id="bottom-center-content">
             
             <!-- Learn Path -->
-            <div class="bottom-center-content-text" v-if="learnerPath=='Discover'">
+            <div class="bottom-center-content-text" v-if="learnerPath=='Explore'">
               <span id="description">
                 <p>Click a highlighted city to view the eclipse from that location.</p>
                 <p>Explore until you can identify which locations will see an annular eclipse</p>
@@ -135,8 +137,8 @@
               </span>
             </div>
             
-            <!-- Explore Path -->
-            <div class="bottom-center-content-text" v-if="learnerPath=='Explore'">
+            <!-- Choose Path -->
+            <div class="bottom-center-content-text" v-if="learnerPath=='Choose'">
               <span id="description">Click a location on the map to select any place you like.</span>
             </div>
             
@@ -164,8 +166,6 @@
               @activate="copyShareURL"
             ></icon-button>
           </div>
-          
-        </div>
       </v-col>
     </v-row>
   </v-card>
@@ -844,7 +844,7 @@ export default defineComponent({
         radius: 50000
       },
 
-      learnerPath: "Explore", // Explore or Learn
+      learnerPath: "Choose", // Choose or Learn
       
       playing: false,
       playingIntervalId: null as ReturnType<typeof setInterval> | null,
@@ -2250,10 +2250,19 @@ video {
   }
 }
 
+    
+@media (max-width: 750px){ //SMALL
+
+}
+
+@media (min-width: 751px){ //LARGE
+
+}
+
 #guided-content-container {
   --margin: 0px;
   position: relative;
-  top: 0; 
+  top: 5px; 
   left: 0;
   width: calc(100% - 2*var(--margin));
   height: fit-content; 
@@ -2270,13 +2279,27 @@ video {
   user-select: none;
   
   transition: height 0.5s ease-in-out;
-  
-  @media (max-width: 600px) { // styles in here will apply to screens smaller than 600px wide
-    font-size: 0.75rem;
-  }
-  
-  @media (min-size:750px) { // styles in here will apply to screens larger than 750px wide
 
+  .v-row {
+    margin: 0px;
+  }
+
+  .v-col {
+    padding: 0px;
+  }
+
+  .leaflet-control-zoom-in,
+  .leaflet-control-zoom-out {
+    width: 5em; 
+    height: 5em; 
+    font-size: 0.4em; 
+    background-color: #fff;
+    border: 1px solid #ccc; 
+    cursor: pointer; /* Change cursor on hover */
+}
+
+  .leaflet-touch {
+    line-height: 5em;
   }
 
   #top-row {
@@ -2296,29 +2319,42 @@ video {
   
   div.icon-wrapper {
     background-color: rgba(209, 209, 209, .2);
-    // box-shadow: 0px 0px 5px rgba(27, 27, 27, 0.7);
     border: none;
     border-radius: 5px;
     padding-inline: 10px;
     padding-block: 3px;
     width: 100%;
-    margin-inline: 10px;
     justify-content: center;
+        
+    @media (max-width: 750px){ //SMALL
+      margin-inline: 4px;
+    }
+
+    @media (min-width: 751px){ //LARGE
+      margin-inline: 10px;
+    }
   }
     
 }
-  
   #bottom-guided-content {
     // map stuff
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
     justify-content: center;
-    
+
+    @media (max-width: 750px){ //SMALL
+      width: 95%;
+    }
+
+    @media (min-width: 751px){ //LARGE
+      width: 70%;
+      padding-bottom: 1.5em;
+    }
+
   
     #map-holder {
       // width: 90%;
-      height: fit-content;
       pointer-events: auto;
       margin-inline: auto;
       
@@ -2330,10 +2366,9 @@ video {
       }
       
       #map-container-map {
-        height: 230px;
-        width: 350px;
-        aspect-ratio: 2 / 1;
+        aspect-ratio: 5 / 3;
         background-color: cornsilk;
+        border-radius: 5px;
         
         span {
           font-weight: bold;
@@ -2349,18 +2384,46 @@ video {
       }
       
     }
-    
+
     #bottom-center-content {
       // text guidelines
-
       .bottom-center-content-text {
         color: white;
-        font-size: 1em;
-        text-align: center;
-        margin: 1em;
-        padding: 0;
-        
+        text-align: left;
+        line-height: 1.2em;
+        border: 1.5px solid var(--accent-color);
+        border-radius: 5px; 
+
+      @media (max-width: 750px) { // SMALL for screensize smaller than or equal to 750px
+        font-size: 0.7em;
+        margin: 0.7em;
+        padding-inline: 0.7em;
+        padding-top: 0.7em;
+        padding-bottom: 0.3em;
+        line-height: 1.2em;
+        border: 1.5px solid var(--accent-color);
+        border-radius: 5px; 
+
+        p {
+          padding-bottom: 0.4em;
+        }
       }
+  
+      @media (min-width:751px) {  // LARGE for screensize greater than or equal to 751px
+        font-size: 1em;
+        margin: 1em;
+        padding-inline: 1em;
+        padding-top: 1em;
+        padding-bottom: 0.4em;
+        line-height: 1.2em;
+        border: 1.5px solid var(--accent-color);
+        border-radius: 5px; 
+
+        p {
+          padding-bottom: 0.6em;
+        }
+      }
+    }
       
       #location-time-display {
         margin: 1em;
@@ -2368,17 +2431,29 @@ video {
         flex-direction: row;
         flex-grow: 1;
         gap: 0.5rem;
-        
       
         .ltd-container {
           // display: block;
-          padding-inline: 0.5em;
-          margin-bottom: 0.5em;
           text-align: left;
           background-color: aliceblue;
           color: blue;
           border-radius: 0.5em;
           flex-grow: 1;
+
+          @media (max-width: 750px){ //SMALL
+            padding-left: 0.5em;
+            padding-block: 0.4em;
+            margin-bottom: 0.3em;
+            font-size: 0.6em;
+          }
+
+          @media (min-width: 751px){ //LARGE
+            padding-left: 1em;
+            padding-block: 0.7em;
+            margin-bottom: 0.5em;
+            text-align: left;
+            font-size: 0.8em;
+          }
         }
         
         .ltd-label {

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -68,13 +68,6 @@
           <v-col>
             <div id="top-container-buttons">
               <icon-button
-                fa-icon="question"
-                :color="accentColor"
-                :focus-color="accentColor"
-                tooltip-location="start"
-                @activate="() => { inIntro=true; introSlide = 2 }"
-              ></icon-button>
-              <icon-button
                 :model-value="learnerPath == 'Explore'"
                 fa-icon="rocket"
                 :color="accentColor"
@@ -121,6 +114,13 @@
                 @activate="() => trackSun()"
               >
               </icon-button>
+              <icon-button
+                fa-icon="question"
+                :color="accentColor"
+                :focus-color="accentColor"
+                tooltip-location="start"
+                @activate="() => { inIntro=true; introSlide = 2 }"
+              ></icon-button>
             </div>
           </v-col>
         </v-row>
@@ -849,7 +849,7 @@ export default defineComponent({
         radius: 50000
       },
 
-      learnerPath: "Choose", // Choose or Learn
+      learnerPath: "Explore", // Choose or Learn
       
       playing: false,
       playingIntervalId: null as ReturnType<typeof setInterval> | null,
@@ -2324,19 +2324,12 @@ video {
     line-height: 5em;
   }
 
-  #top-row {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    width: 90%;
-  }
-
   #top-container-buttons {
     // buttons
     display: flex;
     flex-direction: row;
     justify-content: space-between;
-    width: 90%;
+    padding-right: 0.4em;
   
     div.icon-wrapper {
       background-color: rgba(209, 209, 209, .2);
@@ -2351,8 +2344,13 @@ video {
       }
 
       @media (min-width: 751px){ //LARGE
-        margin-inline: 10px;
+        margin-inline: 6px;
       }  
+
+      &.active {
+        border: 1.5px solid var(--accent-color);
+      }
+
     }
   }
     

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -5,7 +5,7 @@
 >
 
   <!-- Top content box with map, location, time, and option icons -->
-  
+
   <v-card id="guided-content-container">
     <v-row id="top-row">
       <v-col cols="1">
@@ -35,6 +35,7 @@
             :focus-color="accentColor"
             tooltip-location="start"
             @activate="() => { inIntro=true; introSlide = 2 }"
+            class="icon-wrapper top-icons"
           ></icon-button>
           <icon-button
             :model-value="learnerPath == 'Explore'"
@@ -87,10 +88,14 @@
         </div>
       </v-col>
     </v-row>
+    <v-row id="title-row">
+      <v-col>
+        What will the eclipse look like here?
+      </v-col>
+    </v-row>
     <v-row v-if="showGuidedContent" id="bottom-guided-content">
       <v-col :lg="4" :sm="6">
         <div id="map-holder">
-          <span id="title">What will the eclipse look like here?</span>
           <div id="map-container-map">
             <location-selector
               v-if="learnerPath == 'Explore'"
@@ -139,7 +144,7 @@
             
             <!-- Choose Path -->
             <div class="bottom-center-content-text" v-if="learnerPath=='Choose'">
-              <span id="description">Click a location on the map to select any place you like.</span>
+              <p id="description">Click a location on the map to select any place you like.</p>
             </div>
             
             <div id="location-time-display">
@@ -1916,10 +1921,6 @@ body {
 
 }
 
-.icon-wrapper {
-  padding: 8px 16px;
-}
-
 #viewer-mode-switch {
   position: absolute;
   top: 1rem;
@@ -1958,6 +1959,7 @@ body {
   align-items: center;
   gap: 5px;
 }
+
 #tools {
   z-index: 10;
   color: #fff;
@@ -1985,6 +1987,10 @@ body {
   align-items: center;
   gap: 5px;
   pointer-events: auto;
+
+  div.icon-wrapper {
+  padding: 8px 16px;
+  }
 }
 
 #controls {
@@ -2315,27 +2321,42 @@ video {
     flex-direction: row;
     justify-content: space-between;
     width: 90%;
-  }  
   
-  div.icon-wrapper {
-    background-color: rgba(209, 209, 209, .2);
-    border: none;
-    border-radius: 5px;
-    padding-inline: 10px;
-    padding-block: 3px;
-    width: 100%;
-    justify-content: center;
-        
-    @media (max-width: 750px){ //SMALL
-      margin-inline: 4px;
-    }
+    div.icon-wrapper {
+      background-color: rgba(209, 209, 209, .2);
+      border: none;
+      border-radius: 5px;
+      padding-block: 3px;
+      width: 100%;
+      justify-content: center;
+          
+      @media (max-width: 750px){ //SMALL
+        margin-inline: 4px;
+      }
 
-    @media (min-width: 751px){ //LARGE
-      margin-inline: 10px;
+      @media (min-width: 751px){ //LARGE
+        margin-inline: 10px;
+      }  
     }
   }
     
 }
+  #title-row {
+    color: var(--accent-color);
+    font-weight: bold;
+    text-align: left;
+
+    @media (max-width: 750px){ //SMALL
+      width: 95%;
+      font-size: 0.8rem;
+    }
+
+    @media (min-width: 751px){ //LARGE
+      width: 70%;
+      font-size: 1rem;
+    }
+  }
+
   #bottom-guided-content {
     // map stuff
     display: flex;
@@ -2351,19 +2372,13 @@ video {
       width: 70%;
       padding-bottom: 1.5em;
     }
-
   
     #map-holder {
       // width: 90%;
       pointer-events: auto;
       margin-inline: auto;
       
-      #title {
-        color: var(--accent-color);
-        font-weight: bold;
-        font-size: 0.8rem;
-        margin-bottom: 1rem;
-      }
+
       
       #map-container-map {
         aspect-ratio: 5 / 3;

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -1013,6 +1013,7 @@ export default defineComponent({
     cssVars() {
       return {
         '--accent-color': this.accentColor,
+        '--sky-color': this.skyColor,
         '--app-content-height': this.showTextSheet ? '66%' : '100%',
         '--top-content-height': this.inIntro ? '0px' : (this.showGuidedContent? this.guidedContentHeight : this.guidedContentHeight),
       };
@@ -2354,7 +2355,7 @@ video {
       }  
 
       &.active {
-        border: 1.5px solid var(--accent-color);
+        border: 1.5px solid var(--sky-color);
       }
 
     }
@@ -2433,7 +2434,7 @@ video {
       color: white;
       text-align: left;
       line-height: 1.2em;
-      border: 1.5px solid var(--accent-color);
+      border: 1.5px solid var(--sky-color);
       border-radius: 5px; 
 
       @media (max-width: 750px) { // SMALL for screensize smaller than or equal to 750px
@@ -2442,9 +2443,6 @@ video {
         padding-inline: 0.7em;
         padding-top: 0.7em;
         padding-bottom: 0.3em;
-        line-height: 1.2em;
-        border: 1.5px solid var(--accent-color);
-        border-radius: 5px; 
 
         p {
           padding-bottom: 0.4em;
@@ -2457,9 +2455,6 @@ video {
         padding-inline: 1em;
         padding-top: 1em;
         padding-bottom: 0.4em;
-        line-height: 1.2em;
-        border: 1.5px solid var(--accent-color);
-        border-radius: 5px; 
 
         p {
           padding-bottom: 0.6em;

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -29,13 +29,13 @@
           <v-col>
             <div id="title">
               <span v-if="learnerPath=='Explore'"
-                >Watch the eclipse
+                >Watch and Compare
               </span>
               <span v-if="learnerPath=='Answer'"
-                >Identify the eclipse path
+                >Identify Eclipse Path
               </span>
               <span v-if="learnerPath=='Choose'"
-                >Choose any viewing location
+                >Choose Any Location
               </span>
             </div>
           </v-col>
@@ -45,21 +45,21 @@
             <!-- Learn Path -->
             <div class="instructions-text" v-if="learnerPath=='Explore'">
               <span class="description">
-                <p>Click a highlighted city to view the eclipse from this location.</p>
-                <p>Explore until you can identify which locations will see an annular eclipse</p>
+                <p>Click the highlighted cities to view the eclipse from other locations.</p>
+                <p>Explore until you can identify which locations will see an annular eclipse.</p>
               </span>
             </div>
             
             <div class="instructions-text" v-if="learnerPath=='Answer'">
               <span class="description">
-                <p>Once you have collected enough data to determine the annular eclipse path, click to select it.</p>
+                <p>Have you determined the eclipse path? Click to select it.</p>
                 <p>If you are not sure, click <font-awesome-icon icon="rocket"></font-awesome-icon> to keep exploring.</p>
               </span>
             </div>
             
             <!-- Choose Path -->
             <div class="instructions-text" v-if="learnerPath=='Choose'">
-              <p class="description">Select any location you like by clicking on the map, and view the eclipse from your chosen spot.</p>
+              <p class="description">Select any location you like by clicking on the map, and view the eclipse from there.</p>
             </div>
           </v-col>
         </v-row>
@@ -77,7 +77,7 @@
               </div>
           </v-col>
         </v-row>
-        <v-row class="non-map-row">
+        <v-row id="button-row" class="non-map-row">
           <v-col>
             <div id="top-container-buttons">
               <icon-button
@@ -2347,101 +2347,7 @@ video {
     margin: 0px;
     padding: 0px;
   }
-
-  .leaflet-control-zoom-in,
-  .leaflet-control-zoom-out {
-
-    @media (max-width: 750px){ //SMALL
-      width: 4em; 
-      // height: 5em; 
-      font-size: 0.4em; 
-    }
-
-    background-color: #fff;
-    border: 1px solid #ccc; 
-    cursor: pointer; /* Change cursor on hover */
-  } 
-
-  .leaflet-touch {
-    line-height: 5em;
-  }
-
-  #top-container-buttons {
-    // buttons
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    padding-right: 0.4em;
   
-    div.icon-wrapper {
-      background-color: rgba(209, 209, 209, .2);
-      border: none;
-      border-radius: 5px;
-      padding-block: 3px;
-      width: 100%;
-      justify-content: center;
-          
-      @media (max-width: 750px){ //SMALL
-        margin-inline: 4px;
-      }
-
-      @media (min-width: 751px){ //LARGE
-        margin-inline: 6px;
-      }  
-
-      &.active {
-        border: 2px solid var(--sky-color);
-      }
-
-    }
-  }
-  
-  .non-map-row {
-    display: flex;
-    width: 95%;
-    padding-left: 1em;
-  }  
-
-  #map-column {
-    // map stuff
-    align-content: center;
-    justify-content: center;
-    height: 95%;
-    width: 95%;
-  
-    #map-container {
-      pointer-events: auto;
-      height: 100%;
-      width: 100%;
-
-      @media (max-width: 550px){ //SMALL
-        font-size: 0.8rem;
-        aspect-ratio: 3/4; // need to set this to some reasonable value or you just get a tiny horizontal strip
-      }
-
-      @media (min-width: 551px){ //LARGE
-        font-size: 1rem;
-        aspect-ratio: 5/3; // need to set this to some reasonable value or you just get a tiny horizontal strip
-      }
-
-      max-height: var(--map-max-height); // this keeps map from spilling outside the top div for some window aspect ratios
-      
-      .leaflet-map {
-        height: 100%;
-        width: 100%;
-      }
-      span {
-        color: black;
-        padding: 0;
-        margin: 0;
-      }
-
-      img {
-        width: 100%;
-      }
-    }
-  }
-
   #close-guided-content-container {
     position: absolute;
     top: 0;
@@ -2453,6 +2359,12 @@ video {
     padding-left: 0.5em;
     padding-top: 0.5em;
   }
+
+  .non-map-row {
+    display: flex;
+    width: 95%;
+    padding-left: 1em;
+  }  
 
   #title-row {
     color: var(--accent-color);
@@ -2482,13 +2394,13 @@ video {
         text-align: left;
         border: 1.5px solid var(--sky-color);
         border-radius: 5px; 
+        margin-top: 0.5em;
+        padding-inline: 0.7em;
+        padding-top: 0.7em;
 
         @media (max-width: 750px) { // SMALL for screensize smaller than or equal to 750px
           font-size: 0.75rem;
           line-height: 1.2em;
-          margin: 0.75em;
-          padding-inline: 0.7em;
-          padding-top: 0.7em;
           padding-bottom: 0.3em;
 
           p {
@@ -2499,9 +2411,6 @@ video {
         @media (min-width:751px) {  // LARGE for screensize greater than or equal to 751px
           font-size: 0.9rem;
           line-height: 1.3em;
-          margin-top: 0.5em;
-          padding-inline: 0.7em;
-          padding-top: 0.7em;
           padding-bottom: 0.2em;
 
           p {
@@ -2550,10 +2459,100 @@ video {
       font-weight: bold;
     }
   }
+
+  #button-row {
+    @media (max-width: 750px){ //SMALL
+      margin-left: -0.8em;
+      padding-left: 0em;
+    }
+
+    #top-container-buttons {
+      // buttons
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+    
+      div.icon-wrapper {
+        background-color: rgba(209, 209, 209, .2);
+        border: none;
+        border-radius: 5px;
+        padding-block: 4px;
+        width: 100%;
+        justify-content: center;
+            
+        @media (max-width: 750px){ //SMALL
+          margin-inline: 1px;
+        }
+
+        @media (min-width: 751px){ //LARGE
+          margin-inline: 5px;
+        }  
+
+        &.active {
+          border: 2px solid var(--sky-color);
+        }
+
+      }
+    }
+  }
+
+  #map-column {
+    // map stuff
+    align-content: center;
+    justify-content: center;
+    height: 95%;
+    width: 95%;
+  
+    #map-container {
+      pointer-events: auto;
+      height: 100%;
+      width: 100%;
+
+      @media (max-width: 550px){ //SMALL
+        font-size: 0.8rem;
+        aspect-ratio: 3/4; // need to set this to some reasonable value or you just get a tiny horizontal strip
+      }
+
+      @media (min-width: 551px){ //LARGE
+        font-size: 1rem;
+        aspect-ratio: 5/3; // need to set this to some reasonable value or you just get a tiny horizontal strip
+      }
+
+      max-height: var(--map-max-height); // this keeps map from spilling outside the top div for some window aspect ratios
+      
+      .leaflet-map {
+        height: 100%;
+        width: 100%;
+      }
+      span {
+        color: black;
+        padding: 0;
+        margin: 0;
+      }
+
+      img {
+        width: 100%;
+      }
+    }
+
+    .leaflet-control-zoom-in, .leaflet-control-zoom-out {
+
+      @media (max-width: 750px){ //SMALL
+        width: 4em; 
+        // height: 5em; 
+        font-size: 0.4em; 
+      }
+
+      background-color: #fff;
+      border: 1px solid #ccc; 
+      cursor: pointer; /* Change cursor on hover */
+    } 
+
+    .leaflet-touch {
+      line-height: 5em;
+    }
+  }
 }
-
-
-
 
 #introduction-overlay {
   position: absolute;

--- a/annular-eclipse-2023/src/main.ts
+++ b/annular-eclipse-2023/src/main.ts
@@ -39,7 +39,8 @@ import {
   faChevronUp,
   faQuestion,
   faMountainSun,
-  faShareNodes
+  faShareNodes,
+  faSquareXmark,
 } from "@fortawesome/free-solid-svg-icons";
 
 library.add(faBookOpen);
@@ -59,6 +60,7 @@ library.add(faChevronUp);
 library.add(faQuestion);
 library.add(faMountainSun);
 library.add(faShareNodes);
+library.add(faSquareXmark);
 
 /** v-hide directive taken from https://www.ryansouthgate.com/2020/01/30/vue-js-v-hide-element-whilst-keeping-occupied-space/ */
 // Extract the function out, up here, so I'm not writing it twice


### PR DESCRIPTION
I hope no one else has been making significant changes to the overall layout and organization because this is a lot. Like the last round of UI updates, this mostly re-arranges divs and css, which means it looks like a lot of code changes, but I haven't added or deleted a lot of lines.

What's here:

- Re-org top content into new columns and rows. Goal was to get the map by itself in a column, so it could have the tallest possible aspect ratio without having to make the top container too large a percentage of the screen real estate
- Add "x" icon to top left to close top container, so it could be separate from the other icons
- New styling for the top content container (bring in sky blue color to add visual interest)
- CSS is responsive to screen width (so smaller fonts are used for smaller screens).
<img width="1160" alt="Screen Shot 2023-09-23 at 10 56 26 PM" src="https://github.com/cosmicds/minids/assets/12750048/978b9835-5623-4b6b-9f26-6350b9ca44b4">



What's still needed:

- [ ] I still haven't decided where the "share" button should go, so I just put it on the opposite corner from the scope/horizon mode switch for now.
- [ ] Vuetify's `v-col` is supposed to have different values for `sm` and `lg` screen sizes, but I wasn't able to figure out how to set those up, so the layout gets pretty wonky on small screen sizes.
- [ ] I think I broke the fix that prevented a dark black rectangle from appearing at the bottom of the screen when the top content is minimized.