### PR TITLE
Show location and time over wwt

### DIFF
--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -357,6 +357,25 @@
       </div>
     </v-dialog>
     
+    <div id="location-time-display">
+      <v-chip 
+        color="blue-grey"
+        prepend-icon="mdi-map-marker-radius"
+        variant="flat"
+        size="small"
+      >
+        <span>{{ selectedLocationText }}</span>
+      </v-chip>
+      <v-chip 
+        color="blue-grey"
+        prepend-icon="mdi-clock"
+        variant="flat"
+        size="small"
+      >
+        <span>{{ selectedLocaledTimeDateString }}</span>
+      </v-chip>
+    </div>
+    
     <div class="bottom-content">
       <div
         id="controls"
@@ -438,7 +457,7 @@
             v-model="selectedTime"
             @change="onTimeSliderChange"
             :data="times"
-            tooltip="always"
+            tooltip="active"
             :tooltip-formatter="(v: number) => 
               toTimeString(new Date(v))
             "
@@ -2621,5 +2640,17 @@ video {
 #share-button {
   margin: auto;
   width: 2em;
+}
+
+#main-content  > #location-time-display  {
+  position: absolute;
+  top: 2px;
+  right: 5px;
+  
+  display: flex;
+  justify-content: flex-end;
+  flex-wrap: wrap-reverse;
+  gap:5px;
+  
 }
 </style>

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -359,21 +359,23 @@
     
     <div id="location-time-display">
       <v-chip 
-        color="blue-grey"
         prepend-icon="mdi-map-marker-radius"
-        variant="flat"
+        variant="outlined"
         size="small"
-      >
-        <span>{{ selectedLocationText }}</span>
-      </v-chip>
+        elevation="2"
+        :text="selectedLocationText"
+        @click="() => {
+          showGuidedContent = true; 
+          learnerPath = 'Choose'
+          }"
+      > </v-chip>
       <v-chip 
-        color="blue-grey"
         prepend-icon="mdi-clock"
-        variant="flat"
+        variant="outlined"
         size="small"
-      >
-        <span>{{ selectedLocaledTimeDateString }}</span>
-      </v-chip>
+        elevation="2"
+        :text="selectedLocaledTimeDateString"
+      > </v-chip>
     </div>
     
     <div class="bottom-content">
@@ -2651,6 +2653,14 @@ video {
   justify-content: flex-end;
   flex-wrap: wrap-reverse;
   gap:5px;
+  
+  .v-chip {
+    border: none;
+    color: black;
+    background-color: var(--accent-color);
+    font-size: 0.8em;
+    opacity: 0.7;
+  }
   
 }
 </style>


### PR DESCRIPTION
Add the location and time to float above the WWT window. To avoid conflicts, I haven't removed the stuff in the guided content, so this component is completely separate from what was there previously
![image](https://github.com/cosmicds/minids/assets/7862929/1248a5c0-70e7-469a-8d4a-1de05fedf637)
