### PR TITLE
Initial location selector view

### DIFF
--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -130,7 +130,7 @@
             :model-value="locationDeg"
             @place="(place: typeof places[number]) => updateLocation(place.name)"
             :detect-location="false"
-            :map-options="mapOptions"
+            :map-options="presetMapOptions"
             :places="places"
             :initial-place="places.find(p => p.name === 'selectedLocation')"
             :place-circle-options="placeCircleOptions"
@@ -148,6 +148,7 @@
             :model-value="locationDeg"
             @update:modelValue="updateLocationFromMap"
             :detect-location="false"
+            :map-options="userSelectedMapOptions"
             :selected-circle-options="selectedCircleOptions"
             class="leaflet-map"
           ></location-selector>
@@ -830,6 +831,13 @@ export default defineComponent({
     moonPlace.set_names(["Moon"]);
     moonPlace.set_classification(Classification.solarSystem);
     moonPlace.set_target(SolarSystemObjects.moon);
+    const initialView = {
+      initialLocation: {
+        latitudeDeg: 38,
+        longitudeDeg: -97
+      },
+      initialZoom: 3
+    };
 
     return {
       showSplashScreen: false, // FIX later
@@ -865,13 +873,16 @@ export default defineComponent({
       syncDateTimeWithWWTCurrentTime: true,
       syncDateTimewithSelectedTime: true,
 
-      mapOptions: {
+      presetMapOptions: {
         templateUrl: "https://tiles.stadiamaps.com/tiles/stamen_watercolor/{z}/{x}/{y}.{ext}",
         minZoom: 1,
         maxZoom: 16,
         attribution: '&copy; <a href="https://www.stadiamaps.com/" target="_blank">Stadia Maps</a> &copy; <a href="https://www.stamen.com/" target="_blank">Stamen Design</a> &copy; <a href="https://openmaptiles.org/" target="_blank">OpenMapTiles</a> &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-        ext: 'jpg'
+        ext: 'jpg',
+        ...initialView
       },
+
+      userSelectedMapOptions: initialView,
 
       eclipsePathLocations: {
         "Albuquerque, NM": {

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -1035,13 +1035,7 @@ export default defineComponent({
       };
     });
 
-    const searchParams = new URLSearchParams(window.location.search);
-    const lat = parseFloat(searchParams.get("lat") ?? "");
-    const lon = parseFloat(searchParams.get("lon") ?? "");
-    if (lat && lon) {
-      this.selectedLocation = "User Selected";
-      this.locationDeg = { latitudeDeg: lat, longitudeDeg: lon };
-    }
+
   },
 
   mounted() {
@@ -1085,19 +1079,29 @@ export default defineComponent({
       // @ts-ignore
       this.wwtControl.renderOneFrame = renderOneFrame.bind(this.wwtControl);
 
+      // Force the render of one frame so that planet textures will be loaded
+      this.wwtControl.renderOneFrame();
+
+      /* eslint-disable @typescript-eslint/no-var-requires */
+      Planets['_planetTextures'][0] = Texture.fromUrl(require("./assets/2023-09-19-SDO-Sun.png"));
+      this.setForegroundImageByName("Digitized Sky Survey (Color)");
+      this.setBackgroundImageByName("Black Sky Background");
+      this.setForegroundOpacity(100);
+      this.updateMoonTexture(true);
+
+      // Handle URL lat/long parameters
+      // We need to do this after the forced render
+      const searchParams = new URLSearchParams(window.location.search);
+      const lat = parseFloat(searchParams.get("lat") ?? "");
+      const lon = parseFloat(searchParams.get("lon") ?? "");
+      if (lat && lon) {
+        this.selectedLocation = "User Selected";
+        this.locationDeg = { latitudeDeg: lat, longitudeDeg: lon };
+      }
+
       this.updateWWTLocation();
       this.setClockSync(false); // set to false to pause
       this.setClockRate(1); //
-
-      setTimeout(() => {
-        Planets['_planetTextures'][0] = this.textureFromAssetImage("2023-09-19-SDO-Sun.png");
-        this.trackSun().then(() => this.positionSet = true);
-        this.setForegroundImageByName("Digitized Sky Survey (Color)");
-        this.setBackgroundImageByName("Black Sky Background");
-        this.setForegroundOpacity(100);
-        this.updateMoonTexture(true);
-        
-      }, 100);
 
       this.playbackRate = 1;  //this.setplaybackRate('8 minutes per second'); // 500;
       
@@ -1109,6 +1113,7 @@ export default defineComponent({
       } else {
         this.startHorizonMode();
       }
+      this.trackSun().then(() => this.positionSet = true);
 
       this.setTimeforSunAlt(10); // 10 degrees above horizon
       

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -1660,11 +1660,15 @@ export default defineComponent({
     },
 
     updateHorizon(when: Date | null = null) {
-      this.removeAnnotations();
-      if (this.showHorizon) {
-        this.createHorizon(when);
-        if (this.showSky) {
-          this.createSky(when);
+      try {
+        this.removeAnnotations();
+      }
+      finally {
+        if (this.showHorizon) {
+          this.createHorizon(when);
+          if (this.showSky) {
+            this.createSky(when);
+          }
         }
       }
     },

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -1073,14 +1073,15 @@ export default defineComponent({
 
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
-      this.wwtControl.renderFrameCallback = this.onWWTRenderFrame;
-
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
       this.wwtControl.renderOneFrame = renderOneFrame.bind(this.wwtControl);
 
       // Force the render of one frame so that planet textures will be loaded
+      // We don't want to attach the callback before this so that we don't mess up sun tracking
       this.wwtControl.renderOneFrame();
+
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      this.wwtControl.renderFrameCallback = this.onWWTRenderFrame;
 
       /* eslint-disable @typescript-eslint/no-var-requires */
       Planets['_planetTextures'][0] = Texture.fromUrl(require("./assets/2023-09-19-SDO-Sun.png"));
@@ -1792,10 +1793,12 @@ export default defineComponent({
         return times[0] + dt - (dt % MILLISECONDS_PER_INTERVAL);
       }
 
-      if (this.times.includes(matchTime(out.rising, this.times))) {
-        this.selectedTime = matchTime(out.rising, this.times);
-      } else if (this.times.includes(matchTime(out.setting, this.times))) {
-        this.selectedTime = matchTime(out.setting, this.times);
+      const risingTime = matchTime(out.rising, this.times);
+      const settingTime = matchTime(out.setting, this.times);
+      if (this.times.includes(risingTime)) {
+        this.selectedTime = risingTime;
+      } else if (this.times.includes(settingTime)) {
+        this.selectedTime = settingTime;
       } else {
         console.log("time not in times array");
         // best to leave it alone so it doesn't jump around

--- a/common/src/components/LocationSelector.vue
+++ b/common/src/components/LocationSelector.vue
@@ -15,6 +15,8 @@ export interface LocationDeg {
 
 interface MapOptions extends TileLayerOptions {
   templateUrl: string;
+  initialLocation?: LocationDeg;
+  initialZoom?: number;
 }
 
 interface Place extends LocationDeg { 
@@ -24,6 +26,16 @@ interface Place extends LocationDeg {
   radius?: number;
   name?: string;
 }
+
+const defaultMapOptions: MapOptions = {
+  templateUrl: 'https://{s}.google.com/vt/lyrs=p&x={x}&y={y}&z={z}',
+  minZoom: 1,
+  maxZoom: 20,
+  subdomains:['mt0','mt1','mt2','mt3'],
+  attribution: `&copy <a href="https://www.google.com/maps">Google Maps</a>`,
+  className: 'map-tiles'
+};
+
 export default defineComponent({
 
   emits: ["place", "update:modelValue", "error"],
@@ -49,13 +61,7 @@ export default defineComponent({
     mapOptions: {
       type: Object as PropType<MapOptions>,
       default() {
-        return {
-          templateUrl: 'https://{s}.google.com/vt/lyrs=p&x={x}&y={y}&z={z}',
-          maxZoom: 20,
-          subdomains:['mt0','mt1','mt2','mt3'],
-          attribution: `&copy <a href="https://www.google.com/maps">Google Maps</a>`,
-          className: 'map-tiles'
-        };
+        return defaultMapOptions;
       }
     },
     initialPlace: {
@@ -111,7 +117,7 @@ export default defineComponent({
     if (this.detectLocation) {
       this.getLocation(true);
     }
-    this.setup();
+    this.setup(true);
   },
 
   data() {
@@ -198,12 +204,18 @@ export default defineComponent({
       });
     },
 
-    setup() {
+    setup(initial=false) {
       const mapContainer = this.$el as HTMLDivElement;
-      const map = L.map(mapContainer).setView([this.modelValue.latitudeDeg, this.modelValue.longitudeDeg], 4);
+      const location: [number, number] = initial && this.mapOptions.initialLocation ?
+        [this.mapOptions.initialLocation.latitudeDeg, this.mapOptions.initialLocation.longitudeDeg] :
+        [this.modelValue.latitudeDeg, this.modelValue.longitudeDeg];
+
+      const initialZoom = this.mapOptions.initialZoom ?? 4;
+      const zoom = initial ? initialZoom : (this.map?.getZoom() ?? initialZoom);
+      const map = L.map(mapContainer).setView(location, zoom);
       
-      const options = { minZoom: 1, maxZoom: 20, ...this.mapOptions };
-      L.tileLayer(this.mapOptions.templateUrl, options).addTo(map);
+      const options = { ...defaultMapOptions, ...this.mapOptions };
+      L.tileLayer(options.templateUrl, options).addTo(map);
 
       this.placeCircles = this.places.map(place => this.circleForPlace(place));
       this.placeCircles.forEach((circle, index) => {


### PR DESCRIPTION
This PR partially resolves #191 by adding options to the location selector to allow setting the initial view location and zoom, and then using these in the eclipse mini.

Since a Leaflet map's `zoomDelta` is 1 by default, I felt it made more sense to put the zoom as 3 instead of 2.5. (Alternatively, we could change the `zoomDelta` for the eclipse mini)