### PR TITLE
Populate eclipse splash screen

### DIFF
--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -2464,7 +2464,8 @@ body {
     
   p.highlight {
     color: var(--moon-color);
-    -webkit-text-stroke: 0.5px var(--accent-color);
+    -webkit-text-stroke: 0.1px var(--accent-color);
+    filter: drop-shadow(0px 0px 0.25em var(--accent-color));
 
     // make uppercase
     font-size: 1.15em;

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -841,7 +841,7 @@ export default defineComponent({
     };
 
     return {
-      showSplashScreen: true, // FIX later
+      showSplashScreen: false, // FIX later
       backgroundImagesets: [] as BackgroundImageset[],
       sheet: null as SheetType,
       layersLoaded: false,

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -104,15 +104,6 @@
                 :tooltip-location="'bottom'"
               ></icon-button>
               <icon-button
-                v-model="showVideoSheet"
-                fa-icon="video"
-                :color="accentColor"
-                :focus-color="accentColor"
-                tooltip-text="Watch video"
-                :tooltip-location="'bottom'"
-              >
-              </icon-button>
-              <icon-button
                 fa-icon="question"
                 :color="accentColor"
                 :focus-color="accentColor"
@@ -618,33 +609,6 @@
         </div>
       </div>
     </div>
-
-    <!-- This contains the video that is displayed when the video icon is clicked. -->
-
-    <v-dialog
-      id="video-container"
-      v-model="showVideoSheet"
-      transition="slide-y-transition"
-      fullscreen
-    >
-      <div class="video-wrapper">
-        <font-awesome-icon
-          id="video-close-icon"
-          class="close-icon"
-          icon="times"
-          size="lg"
-          @click="showVideoSheet = false"
-          @keyup.enter="showVideoSheet = false"
-          tabindex="0"
-        ></font-awesome-icon>
-        <video
-          controls
-          id="info-video"
-        >
-          <source src="" type="video/mp4">
-        </video>
-      </div>
-    </v-dialog>
 
     <!-- This contains the informational content that is displayed when the book icon is clicked. -->
 
@@ -1236,18 +1200,6 @@ export default defineComponent({
       },
       set(_value: boolean) {
         this.selectSheet('text');
-      }
-    },
-    showVideoSheet: {
-      get(): boolean {
-        return this.sheet === "video";
-      },
-      set(value: boolean) {
-        this.selectSheet('video');
-        if (!value) {
-          const video = document.querySelector("#info-video") as HTMLVideoElement;
-          video.pause();
-        }
       }
     },
 
@@ -2536,32 +2488,6 @@ body {
     color: var(--accent-color-3);
     white-space: nowrap;
   }
-}
-
-.video-wrapper {
-  height: 100%;
-  background: black;
-  text-align: center;
-  z-index: 1000;
-}
-
-video {
-  height: 100%;
-  width: auto;
-  max-width: 100%;
-  object-fit: contain;
-}
-
-#video-container {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  overflow: hidden;
-  padding: 0px;
-  z-index: 1000;
 }
 
 .bottom-sheet {

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -206,7 +206,51 @@
         v-click-outside="closeSplashScreen"
         :style="cssVars"
       >
-        Splash Screen
+      <div
+          id="first-splash-row"
+        >
+          <div
+            id="close-splash-button"
+            @click="closeSplashScreen"
+            >&times;</div>
+          <div id="splash-screen-text">
+            <p>WATCH the October </p>
+            <p class="highlight"> Annular Eclipse </p>
+          </div>
+        </div>
+        
+        <div id="splash-screen-guide">
+          <v-row>
+            <v-col cols="12">
+              <font-awesome-icon
+                icon="rocket"
+              /> Explore the view 
+            </v-col>
+            <v-col cols="12">
+              <font-awesome-icon
+                icon="puzzle-piece"
+              /> Identify the path 
+            </v-col>
+            <v-col cols="12">
+              <font-awesome-icon
+                icon="location-dot"
+              /> Choose any location 
+            </v-col>
+            <v-col cols="12">
+              <font-awesome-icon
+                icon="book-open"
+              /> Learn more 
+            </v-col>
+        </v-row>
+        </div>
+        
+        <div id="splash-screen-acknowledgements">
+          This Mini Data Story is brought to you by <a href="https://www.cosmicds.cfa.harvard.edu/" target="_blank" rel="noopener noreferrer">Cosmic Data Stories</a> and <a href="https://www.worldwidetelescope.org/home/" target="_blank" rel="noopener noreferrer">WorldWide Telescope</a>.
+          
+          <div id="splash-screen-icons">
+            <mini-credits/>
+          </div>
+        </div>
       </div>
     </v-overlay>
 
@@ -840,7 +884,7 @@ export default defineComponent({
     };
 
     return {
-      showSplashScreen: false, // FIX later
+      showSplashScreen: true, // FIX later
       backgroundImagesets: [] as BackgroundImageset[],
       sheet: null as SheetType,
       layersLoaded: false,
@@ -999,6 +1043,7 @@ export default defineComponent({
       millisecondsPerInterval: MILLISECONDS_PER_INTERVAL,
       
       accentColor: "#ef7e3d",
+      moonColor: "#CFD8DC",
       guidedContentHeight: "300px",
       showGuidedContent: true,
       inIntro: false,
@@ -1161,6 +1206,7 @@ export default defineComponent({
       return {
         '--accent-color': this.accentColor,
         '--sky-color': this.skyColorLight,
+        '--moon-color': this.moonColor,
         '--app-content-height': this.showTextSheet ? '66%' : '100%',
         '--top-content-height': this.inIntro ? '0px' : (this.showGuidedContent? this.guidedContentHeight : this.guidedContentHeight),
       };
@@ -2392,6 +2438,7 @@ body {
 }
 
 #splash-screen {
+  color: var(--moon-color);
   max-height: calc(min(90vh, 2040px));
   max-width: 90vw;
   background-color: black;
@@ -2403,6 +2450,91 @@ body {
   border: min(1.2vw, 0.9vh) solid var(--accent-color);
   overflow: auto;
   font-family: 'Highway Gothic Narrow', 'Roboto', sans-serif;
+
+  div {
+    margin-inline: auto;
+    text-align: center;
+  }
+  // make a paragraph inside the div centered horizontally and vertically
+  p {
+    font-family: 'Highway Gothic Narrow', 'Roboto', sans-serif;
+    font-weight: bold;
+    vertical-align: middle;
+  }
+    
+  p.highlight {
+    color: var(--moon-color);
+    -webkit-text-stroke: 0.5px var(--accent-color);
+
+    // make uppercase
+    font-size: 1.15em;
+    text-transform: uppercase;
+    font-weight: bolder;
+  }
+  
+  p.small {
+    font-size: .75em;
+    font-weight: bold;
+  }
+
+  #first-splash-row {
+    width: 100%;
+  }
+
+  #close-splash-button {
+    text-align: end;
+    margin-top: 0%;
+    margin-right: 6%;
+    color: var(--accent-color-2);
+    font-size: min(8vw, 5vh);
+
+    &:hover {
+      cursor: pointer;
+    }
+  }
+
+  #splash-screen-text {
+    // in the grid, the text is in the 2nd column
+    display: flex;
+    flex-direction: column;
+    
+  }
+
+  #splash-screen-guide {
+    margin-block: 1em;
+    font-size: .6em;
+    width: 75%;
+
+    .v-col{
+      padding: 0;
+    }
+    
+    .svg-inline--fa {
+      color:var(--accent-color);
+      margin: 0 10px;
+    }
+  }
+
+  #splash-screen-acknowledgements {
+    font-size: .5em;
+    width: 70%; 
+  }
+
+  #splash-screen-icons {
+    margin-top: 0.5em;
+    margin-bottom: 0.75em;
+    
+    #credits {
+      background-color: transparent;
+      border: 2px solid transparent;
+    }
+  }
+  
+  a {
+    text-decoration: none;
+    color: var(--accent-color-3);
+    white-space: nowrap;
+  }
 }
 
 .video-wrapper {

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -103,13 +103,6 @@
                 :tooltip-text="showTextSheet ? 'Hide Info' : 'Learn More'"
                 :tooltip-location="'bottom'"
               ></icon-button>
-              <icon-button
-                fa-icon="question"
-                :color="accentColor"
-                :focus-color="accentColor"
-                :tooltip-location="'bottom'"
-                @activate="() => { inIntro=true; introSlide = 2 }"
-              ></icon-button>
             </div>
           <!-- </v-col> -->
         </v-row>
@@ -857,7 +850,6 @@ export default defineComponent({
 
       showMapTooltip: false,
       showTextTooltip: false,
-      showVideoTooltip: false,
       showControls: true, 
       showMapSelector: false,
       showLocationSelector: false,

--- a/annular-eclipse-2023/src/main.ts
+++ b/annular-eclipse-2023/src/main.ts
@@ -4,6 +4,7 @@ import { IconButton } from "@minids/common";
 import { LocationSelector } from "@minids/common";
 import AnnularEclipse2023 from "./AnnularEclipse2023.vue";
 import TransitionExpand from "./TransitionExpand.vue";
+import  { DefaultMiniCredits } from "@minids/common";
 
 import "./polyfills";
 
@@ -107,6 +108,7 @@ createApp(AnnularEclipse2023, {
   .component('location-selector', LocationSelector)
   .component('vue-slider', VueSlider)  
   .component('transition-expand', TransitionExpand)
+  .component('mini-credits', DefaultMiniCredits)
   .component('date-picker', Datepicker)
 
   // Mount

--- a/common/src/components/DefaultMiniCredits.vue
+++ b/common/src/components/DefaultMiniCredits.vue
@@ -1,9 +1,9 @@
 <template>
   <div id="credits" class="ui-text">
     <div id="icons-container">
-      <a href="https://www.cosmicds.cfa.harvard.edu/" target="_blank"
+      <!-- <a href="https://www.cosmicds.cfa.harvard.edu/" target="_blank"
         ><img alt="CosmicDS Logo" :src="require('../../../assets/cosmicds_logo_for_dark_backgrounds.png')"
-      /></a>
+      /></a> -->
       <!-- <a href="https://worldwidetelescope.org/home/" target="_blank"
         ><img alt="WWT Logo" src="../../../assets/logo_wwt.png"
       /></a>

--- a/common/src/components/DefaultMiniCredits.vue
+++ b/common/src/components/DefaultMiniCredits.vue
@@ -1,0 +1,110 @@
+<template>
+  <div id="credits" class="ui-text">
+    <div id="icons-container">
+      <a href="https://www.cosmicds.cfa.harvard.edu/" target="_blank"
+        ><img alt="CosmicDS Logo" :src="require('../../../assets/cosmicds_logo_for_dark_backgrounds.png')"
+      /></a>
+      <!-- <a href="https://worldwidetelescope.org/home/" target="_blank"
+        ><img alt="WWT Logo" src="../../../assets/logo_wwt.png"
+      /></a>
+      <a href="https://science.nasa.gov/learners" target="_blank" class="pl-1"
+        ><img alt="SciAct Logo" src="../../../assets/logo_sciact.png"
+      /></a>
+      <a href="https://nasa.gov/" target="_blank" class="pl-1"
+        ><img alt="SciAct Logo" src="../../../assets/NASA_Partner_color_300_no_outline.png"
+      /></a> -->
+    </div>
+  </div>
+</template>
+
+
+<script lang="ts">
+import { defineComponent, } from "vue";
+
+
+
+export default defineComponent({
+
+
+  props: {
+    visible: {
+      type: Boolean,
+      default: true
+    },
+  },
+
+  data() {
+    return {    };
+  },
+
+  created() {
+    return;
+  },
+
+  methods: {
+    
+  },
+
+  computed: { 
+
+    isMobile() {
+      return (/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent));
+    },
+  },
+
+  watch: {
+  }
+});
+</script>
+
+
+<style lang="less">
+
+#credits {
+  color: #ddd;
+  font-size: calc(0.7em + 0.2vw);
+  justify-self: flex-end;
+  align-self: flex-end;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  p {
+    margin: 0;
+    padding: 0;
+    line-height: 1;
+  }
+
+  a {
+    text-decoration: none;
+    color: #fff;
+    pointer-events: auto;
+
+    &:hover {
+      text-decoration: underline;
+    }
+
+    &[class^="share-network"]:hover {
+      text-decoration: none;
+      filter: brightness(75%);
+    }
+  }
+
+  img {
+    height: 35px;
+    vertical-align: middle;
+    margin: 2px;
+  }
+
+  @media only screen and (max-width: 600px) {
+  img {
+    height: 24px;
+  }
+}
+
+  svg {
+    vertical-align: middle;
+    height: 24px;
+  }
+}
+</style>

--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -2,6 +2,7 @@ import { KeyboardControlSettings } from "./keyboard";
 import MiniDSBase from "./components/MiniDSBase";
 import IconButton from "./components/IconButton.vue";
 import LocationSelector from "./components/LocationSelector.vue";
+import DefaultMiniCredits from "./components/DefaultMiniCredits.vue";
 import { BackgroundImageset, skyBackgroundImagesets } from "./background";
 import Gallery from "./components/Gallery.vue";
 
@@ -12,5 +13,6 @@ export {
   Gallery,
   IconButton,
   LocationSelector,
-  skyBackgroundImagesets
+  skyBackgroundImagesets,
+  DefaultMiniCredits
 };


### PR DESCRIPTION
This puts content into the splash screen and removes the video and ? buttons from the top container.

To make on-going development easier, I've left `showSplashScreen: false`. We'll need to remember to reset that to `true` before we release.