### PR TITLE
Hide map attribution until hovering over credits

### DIFF
--- a/common/src/components/LocationSelector.vue
+++ b/common/src/components/LocationSelector.vue
@@ -300,7 +300,7 @@ export default defineComponent({
   border-radius: 5px;
   
   .leaflet-bottom.leaflet-right::before {
-    content: "&copy; Credit: Leaflet.js";
+    content: " Credit: © Leaflet.js";
     top: 100%;
     left: 100%;
     transform: translate(-100%, -100%);

--- a/common/src/components/LocationSelector.vue
+++ b/common/src/components/LocationSelector.vue
@@ -298,5 +298,38 @@ export default defineComponent({
   margin: auto;
   padding: 5px 0px;
   border-radius: 5px;
+  
+  .leaflet-bottom.leaflet-right::before {
+    content: "&copy; Credit: Leaflet.js";
+    top: 100%;
+    left: 100%;
+    transform: translate(-100%, -100%);
+    pointer-events: auto;
+  }
+
+  .leaflet-bottom.leaflet-right::before {
+    /* match formatting for actual attribution */
+    color: #0078a8;
+    background-color: rgba(255,255,255,0.8);
+    font-size: 0.75em;
+    padding-inline: 0.5em;
+    padding-block: 0.3em;
+  }
+
+  .leaflet-bottom.leaflet-right:hover::before {
+    content: "";
+    background-color: transparent;
+  }
+
+  .leaflet-bottom.leaflet-right:hover > .leaflet-control-attribution {
+    display: block;
+  }
+
+
+  .leaflet-control-attribution {
+    display: none;
+  }
+
+  
 }
 </style>


### PR DESCRIPTION
The resolves #214. Hovering over the credits will show the full unmodified credits. 

Is there something else we want to say? The way this is implemented (using the `::before` psuedo-element to inject some text) it can only show raw text. 

![image](https://github.com/cosmicds/minids/assets/7862929/0e225a59-9be5-41af-820e-02b4c68b0e3b)
