### PR TITLE
Don't show border rings for Leaflet circles on mouse focus

### DIFF
--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -1087,13 +1087,15 @@ export default defineComponent({
   },
 
   created() {
-    this.places = Object.entries(this.eclipsePathLocations).filter(([key, _]) => key !== "User Selected").map(([_, pl]) => {
-      return {
-        ...pl,
-        latitudeDeg: R2D * pl.latitudeRad,
-        longitudeDeg: R2D * pl.longitudeRad
-      };
-    });
+    this.places = Object.entries(this.eclipsePathLocations).filter(([key, _]) => key !== "User Selected")
+      .sort(([_, pl1], [__, pl2]) => pl1.longitudeRad - pl2.longitudeRad)
+      .map(([_, pl]) => {
+        return {
+          ...pl,
+          latitudeDeg: R2D * pl.latitudeRad,
+          longitudeDeg: R2D * pl.longitudeRad
+        };
+      });
 
 
   },

--- a/common/src/components/LocationSelector.vue
+++ b/common/src/components/LocationSelector.vue
@@ -330,6 +330,14 @@ export default defineComponent({
     display: none;
   }
 
+  path.leaflet-interactive:focus {
+    outline: none;
+  }
+
+  path.leaflet-interactive:focus-visible {
+    outline: auto 5px black;
+  }
+
   
 }
 </style>


### PR DESCRIPTION
This PR adds some CSS so that the circles in the location selector map won't show the border ring if they're focused via a click, but will if they're focused via another method (e.g. tab-focusing).

Additionally, I sorted the places in the eclipse mini from west to east, just to give some sort of logic to the tab ordering there.