### PR TITLE
Update eclipse text everywhere

### DIFF
--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -54,14 +54,15 @@
             <div class="instructions-text" v-if="learnerPath=='Answer'">
               <span class="description">
                 <p>Have you determined the eclipse path? Click to select it.</p>
-                <p>If you are not sure, click <font-awesome-icon icon="rocket"></font-awesome-icon> to keep exploring.</p>
+                <p>If you are not sure, click <font-awesome-icon icon="rocket" class="bullet-icon"/> to keep exploring.</p>
               </span>
             </div>
             
             <!-- Choose Path -->
             <div class="instructions-text" v-if="learnerPath=='Choose'">
               <span class="description">
-                <p>Select any location you like by clicking on the map, and view the eclipse from there.</p>
+                <p>Select any location you like by double-clicking on the map, and view the eclipse from there.</p>
+                <p>You can create a url that shares the view from a location by clicking <font-awesome-icon icon="share-nodes" class="bullet-icon"/>.</p>
               </span>
             </div>
           </v-col>
@@ -103,12 +104,22 @@
                 @activate="() => { learnerPath = 'Choose'}"
               ></icon-button>
               <icon-button
-                v-model="showTextSheet"
+                v-model="showInfoSheet"
                 fa-icon="book-open"
                 fa-size="xl"
                 :color="accentColor"
                 :focus-color="accentColor"
-                :tooltip-text="showTextSheet ? 'Hide Info' : 'Learn More'"
+                :tooltip-text="showInfoSheet ? 'Hide Info' : 'More on Eclipses'"
+                :tooltip-location="'bottom'"
+                :box-shadow="false"
+              ></icon-button>
+              <icon-button
+                v-model="showWWTGuideSheet"
+                fa-icon="computer-mouse"
+                fa-size="xl"
+                :color="accentColor"
+                :focus-color="accentColor"
+                :tooltip-text="showWWTGuideSheet ? 'Hide Info' : 'Feature Guide'"
                 :tooltip-location="'bottom'"
                 :box-shadow="false"
               ></icon-button>
@@ -172,7 +183,7 @@
     <v-dialog
       scrim="false"
       transition="slide-y-transition"
-      v-model="showTextSheet" 
+      v-model="showInfoSheet" 
       class='bottom-sheet'
       id="text-bottom-sheet"
       :style="cssVars"
@@ -196,8 +207,8 @@
           class="control-icon"
           icon="times"
           size="lg"
-          @click="showTextSheet = false"
-          @keyup.enter="showTextSheet = false"
+          @click="showInfoSheet = false"
+          @keyup.enter="showInfoSheet = false"
           tabindex="0"
         ></font-awesome-icon>
         <v-window v-model="tab" id="tab-items" class="pa-2 no-bottom-border-radius">
@@ -208,10 +219,13 @@
                 <v-col cols="6" id="info-text-box">
                   <div id="main-info-text">
                     <p>
-                    Get ready North America for not one, but two brilliant solar eclipses! 
-                    First, a dazzling annular or <i>Ring of Fire</i> eclipse on October 14, 2023. Only 6 months late, on April 8, 2024,
-                    get ready for an awe-inspiring solar eclipse which stretches from coast-to-coast across the United States.
-                    This interactive lets you explore the October "Ring of Fire" eclipse from different locations.
+                    Get ready, North America, for not one, but two solar eclipses! On October 14, 2023, North, Central, and South America will be treated to a beautiful annular eclipse. Only 6 months later, on April 8, 2024, an awe-inspiring total solar eclipse will stretch from coast-to-coast across the United States and Canada.
+                    </p>
+                    <p>
+                    This interactive lets you explore the October "Ring of Fire" eclipse from different locations. 
+                    </p>
+                    <p id="safety-warning">
+                      SAFETY FIRST: NEVER look directly at the Sun without proper eye protection.
                     </p>
                   </div>  
                     <div id="FAQ">
@@ -219,29 +233,25 @@
                         <summary>
                           What causes Solar Eclipses?
                         </summary>
-                      <p>A solar eclipse happens when the Moon passes between the Earth and the Sun and blocks the Sun from our view.
-                        Partial eclipses occur about every 6 months somewhere on the Earth (Can you think of WHY this is?). The U.S. is lucky 
-                        to be in the path of the next two solara eclipses. 
+                        <p>
+                          A solar eclipse happens when the Moon passes between the Earth and the Sun and blocks the Sun from our view. Partial eclipses occur about every 6 months, somewhere on the Earth. The U.S. is lucky to be in the path of the next two solar eclipses. 
                         </p>
                       </details>
                       
                       <details>
                         <summary> Total vs. Annular Eclipse</summary>
                         <p>
-                          During a Total Eclipse, the Moon covers the entire face of the Sun. Because the Moon doesn't orbit the Earth
-                          in a perfect circle, sometimes it is farther away from the Earth and appears smaller. When this happens, the Moon
-                          doesn't cover the entire face of the Sun, and during the eclipse we can still see a ring of light around the Moon. This is called an Annular Eclipse.
+                          During a total eclipse, the Moon covers the entire face of the Sun. Because the Moon doesn't orbit the Earth in a perfect circle, sometimes it is farther away from Earth and appears smaller. When this happens, the Moon doesn't cover the entire face of the Sun, and during the eclipse we can still see a bright ring of light around the Moon. This is called an Annular Eclipse.
                         </p>
                       </details>
                       
                       <details> 
                         <summary> Why can only some places see the eclipse?</summary>
                         <p>
-                          An eclipse is caused by the Moon casting a shadow on the Earth. 
-                          People who are directly behind the Moon are in the darkest part of the shadow, and will see an annular (Oct) or total (Apr) eclipse. 
-                          As the Moon moves in its orbit around the Earth, the location of the shadow will move, sweeping out a path across the surface of the Earth. 
-                          For a larger number of people, those not directly behind the moon, the Sun will only be partially blocked, causing a partial eclipse. Even further outside the shadow
-                          the Sun will not be blocked at all, and there will be no eclipse visible. 
+                          An eclipse is caused by the Moon casting a shadow on the Earth. People who are directly behind the Moon will see an annular or total eclipse. As the Moon moves in its orbit around Earth, and as Earth rotates, the location of the shadow will move, sweeping out a path across the surface of the Earth. For a larger number of people who are not directly behind the moon, a smaller amount of the Sun will be blocked, causing a partial eclipse. Even further outside the shadow the Sun will not be blocked at all, and there will be no eclipse visible.
+                        </p>
+                        <p> 
+                          The figure shows the parts of Earth that are directly behind the Moon (in the darkest shadow) and partially behind the moon (in the lighter shadow).
                         </p> 
                       </details>
                     </div>
@@ -1047,7 +1057,7 @@ export default defineComponent({
       showAltAzGrid: true,
       showHorizon: true,
       showEcliptic: false, 
-      showTextSheet: false,   
+      showInfoSheet: false,   
       
       toggleTrackSun: true,
       
@@ -1229,7 +1239,7 @@ export default defineComponent({
       return {
         '--accent-color': this.accentColor,
         '--sky-color': this.skyColorLight,
-        '--app-content-height': this.showTextSheet ? '100%' : '100%',
+        '--app-content-height': this.showInfoSheet ? '100%' : '100%',
         '--top-content-height': this.inIntro ? '0px' : (this.showGuidedContent? this.guidedContentHeight : this.guidedContentHeight),
         '--moon-color': this.moonColor,
       };
@@ -1253,7 +1263,7 @@ export default defineComponent({
       const todMs = 1000 * (3600 * dateForTOD.getUTCHours() + 60 * dateForTOD.getUTCMinutes() + dateForTOD.getUTCSeconds());
       return todMs / MILLISECONDS_PER_DAY;
     },
-    // showTextSheet: {
+    // showInfoSheet: {
     //   get(): boolean {
     //     return this.sheet === 'text';
     //   },
@@ -2281,8 +2291,9 @@ body {
   left: 1rem;
   
   .icon-wrapper {
-    padding-inline: 7px 8px;
-    width: 2.5rem;
+    padding-inline: 0.5em;
+    padding-block: 0.6em;
+    border: 2px solid var(--accent-color);
   }
 
 }
@@ -2594,6 +2605,13 @@ body {
   }
   #main-info-text {
     padding-inline: 0.5em;
+  }
+
+  #safety-warning{
+    margin-top: 0.4em;
+    font-weight: bold;
+    color: var(--accent-color);
+    font-size: ~"max(20px, calc(1em + 0.3vw))";
   }
   
   #FAQ{

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -431,15 +431,14 @@
               </p>
             <br />
               <p>
-              A lucky segment of the U.S., Central, and South America will 
-              experience what is known as an <b>annular eclipse</b>.
+              A lucky segment of the U.S., Central, and South America will experience a dazzling <b>"Ring of Fire"</b> created by an <b>annular eclipse</b>.
               </p>
             </div>
           </v-window-item>
           
           <v-window-item :value="2">
-            <div class="intro-text">
-              <p>
+            <div class="intro-text mb-3">
+              <p class="mb-3">
                 In this interactive page you can:
               </p>
               
@@ -449,13 +448,13 @@
                   <template v-slot:prepend>
                     <font-awesome-icon icon="rocket" size="xl" class="bullet-icon"></font-awesome-icon>
                   </template>
-                    Explore what the eclipse will look like from different parts of the country
+                    Explore what the eclipse will look like from different parts of the U.S.
                 </v-list-item>
                 <v-list-item>
                   <template v-slot:prepend>
                     <font-awesome-icon icon="puzzle-piece" size="xl" class="bullet-icon"></font-awesome-icon>
                   </template>
-                    Use some detective work to identify the Path of Visibility for the annular eclipse
+                    Use some detective work to identify the Path of Visibility in the U.S. for the annular eclipse
                 </v-list-item>
                 <v-list-item>
                   <template v-slot:prepend>
@@ -467,7 +466,7 @@
                   <template v-slot:prepend>
                     <font-awesome-icon icon="book-open" size="xl" class="bullet-icon"></font-awesome-icon>
                   </template>
-                    Learn more about solar eclipses. 
+                    Learn more about solar eclipses 
                 </v-list-item>
               </ul>
             </div>
@@ -1060,7 +1059,7 @@ export default defineComponent({
       moonColor: "#CFD8DC",
       guidedContentHeight: "300px",
       showGuidedContent: true,
-      inIntro: false,
+      inIntro: false, //FIX
 
       tab: 0,
       introSlide: 1,

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -2895,17 +2895,7 @@ body {
     text-align: right;
     padding-left: 1rem;
     
-    @media (max-width: 390px){ //TINY
-      font-size: 0.9rem;
-    }
-
-    @media (max-width: 750px){ //SMALL
-      font-size: 1.1rem;
-    }
-
-    @media (min-width: 751px){ //LARGE
-      font-size: 1.3rem;
-    }
+    font-size: clamp(0.9rem, 2.1vw, 2rem);
 
   }
     

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -189,7 +189,7 @@
       :style="cssVars"
     >
       <v-card
-        id="bottom-sheet-card">
+        class="bottom-sheet-card">
         <v-tabs
           v-model="tab"
           height="32px"
@@ -2696,7 +2696,7 @@ body {
     margin: unset;
   }
   
-  #bottom-sheet-card {
+  .bottom-sheet-card {
     height: fit-content;
     width: 100%;
     align-self: center;
@@ -2708,8 +2708,7 @@ body {
   }
 
   .v-card-text {
-    height: 33vh;
-    padding-bottom: 25px;
+    height: 40vh;
     
     & a {
       text-decoration: none;

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -2922,15 +2922,7 @@ body {
         padding-inline: 0.7em;
         padding-block: 0.4em; // this plus the margin on p give .7 em on top and bottom
         
-        @media (max-width: 600px){ //SMALL
-          font-size: 0.9rem;
-        }
-        @media (min-width: 601px){ //MEDIUM
-          font-size: 1.1rem;
-        }
-        @media (min-width: 900px){ //LARGE
-          font-size: 1.2rem;
-        }
+        font-size: clamp(0.6rem, 1.75vw, 1.2rem);
 
         // span
         .description {

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -9,7 +9,7 @@
     <div id="close-guided-content-container">
       <font-awesome-icon
         v-model="showGuidedContent"
-        size="lg"
+        size="xl"
         class="ma-1"
         :color="accentColor"
         :icon="`square-xmark`"
@@ -75,6 +75,7 @@
                 :focus-color="accentColor"
                 :tooltip-text="'View eclipse from multiple locations'"
                 :tooltip-location="'bottom'"
+                :box-shadow="false"
                 @activate="() => { learnerPath = 'Explore'}"
               ></icon-button>
               <icon-button
@@ -84,6 +85,7 @@
                 :focus-color="accentColor"
                 :tooltip-text="'Identify eclipse path'"
                 :tooltip-location="'bottom'"
+                :box-shadow="false"
                 @activate="() => { learnerPath = 'Answer'}"
               ></icon-button>   
               <icon-button
@@ -93,6 +95,7 @@
                 :focus-color="accentColor"
                 :tooltip-text="'Choose any viewing location'"
                 :tooltip-location="'bottom'"
+                :box-shadow="false"
                 @activate="() => { learnerPath = 'Choose'}"
               ></icon-button>
               <icon-button
@@ -102,6 +105,7 @@
                 :focus-color="accentColor"
                 :tooltip-text="showTextSheet ? 'Hide Info' : 'Learn More'"
                 :tooltip-location="'bottom'"
+                :box-shadow="false"
               ></icon-button>
             </div>
           <!-- </v-col> -->
@@ -619,57 +623,59 @@
 
       <div id="tools">
         <span class="tool-container">
-          <icon-button
-            id="play-pause-icon"
-            :fa-icon="!(playing) ? 'play' : 'pause'"
-            @activate="() => {
-              playing = !(playing);
-            }"
-            :color="accentColor"
-            :focus-color="accentColor"
-            tooltip-text="Play/Pause"
-            tooltip-location="top"
-            tooltip-offset="5px"
-          ></icon-button>
-          <icon-button
-            id="speed-down"
-            :fa-icon="'angle-double-down'"
-            @activate="() => {
-                  speedIndex -= 1;
-                  playbackRate = Math.pow(10, speedIndex);
-                  playing = true;
-                }"
-            :color="accentColor"
-            :focus-color="accentColor"
-            tooltip-text="10x slower"
-            tooltip-location="top"
-            tooltip-offset="5px"
-          ></icon-button>
-          <icon-button
-            id="speed-up"
-            :fa-icon="'angle-double-up'"
-            @activate="() => {
-                  speedIndex += 1;
-                  playbackRate = Math.pow(10, speedIndex);
-                  playing = true;
-                }"
-            :color="accentColor"
-            :focus-color="accentColor"
-            tooltip-text="10x faster"
-            tooltip-location="top"
-            tooltip-offset="5px"
-          ></icon-button>
-          <div id="speed-text">
-            Time rate: 
-            <span v-if="playbackRate===1 && playing">
-              Real time
-            </span>
-            <span v-if="playbackRate!=1 && playing">
-              {{ playbackRate }}&times;
-            </span>
-            <span v-if="!playing">
-              Paused
-            </span>
+          <div id="speed-control">
+            <icon-button
+              id="play-pause-icon"
+              :fa-icon="!(playing) ? 'play' : 'pause'"
+              @activate="() => {
+                playing = !(playing);
+              }"
+              :color="accentColor"
+              :focus-color="accentColor"
+              tooltip-text="Play/Pause"
+              tooltip-location="top"
+              tooltip-offset="5px"
+            ></icon-button>
+            <icon-button
+              id="speed-down"
+              :fa-icon="'angle-double-down'"
+              @activate="() => {
+                    speedIndex -= 1;
+                    playbackRate = Math.pow(10, speedIndex);
+                    playing = true;
+                  }"
+              :color="accentColor"
+              :focus-color="accentColor"
+              tooltip-text="10x slower"
+              tooltip-location="top"
+              tooltip-offset="5px"
+            ></icon-button>
+            <icon-button
+              id="speed-up"
+              :fa-icon="'angle-double-up'"
+              @activate="() => {
+                    speedIndex += 1;
+                    playbackRate = Math.pow(10, speedIndex);
+                    playing = true;
+                  }"
+              :color="accentColor"
+              :focus-color="accentColor"
+              tooltip-text="10x faster"
+              tooltip-location="top"
+              tooltip-offset="5px"
+            ></icon-button>
+            <div id="speed-text">
+              Time rate: 
+              <span v-if="playbackRate===1 && playing">
+                Real time
+              </span>
+              <span v-if="playbackRate!=1 && playing">
+                {{ playbackRate }}&times;
+              </span>
+              <span v-if="!playing">
+                Paused
+              </span>
+            </div>
           </div>
           <v-slider
             id="slider"
@@ -2727,9 +2733,18 @@ body {
     min-width: fit-content;
     white-space: nowrap;
     color: black;
-    font-size: .9rem;
-    padding: 0.5rem;
+    padding-inline: 0.7rem;
     background-color: var(--accent-color);
+
+    @media (max-width: 750px ) { //SMALL
+      font-size: 1rem;
+      padding-block: 0.7rem;
+    } 
+
+    @media (min-width: 751px ) { //LARGE
+      font-size: 1.1rem;
+      padding-block: 1rem;
+    } 
   }
   
   .v-slider-thumb__label::before {
@@ -2745,6 +2760,13 @@ body {
 .v-container {
   max-width: 100%;
 }
+
+#closed-top-container {
+    position: absolute;
+    margin-top: 0.5rem;
+    margin-left: 0.5rem;
+    z-index: 500;
+  }
 
 #guided-content-container {
   --top-content-max-height: max(30vmin, 35vh);
@@ -2762,7 +2784,7 @@ body {
   // border-bottom: 1px solid var(--accent-color);
   background-color: #272727;
   user-select: none;
-  border: solid 1px var(--accent-color);
+  border: solid 1.5px var(--accent-color);
   
   font-size: clamp(8px, 3vmin, 0.9em);
   overflow-y: auto;
@@ -2783,13 +2805,13 @@ body {
     margin: 0px;
     padding: 0px;
   }
-  
+
   #close-guided-content-container {
     position: absolute;
     top: 0;
     left: 0;
     z-index: 500;
-  }
+  }  
 
   #non-map-container { // Keep content away from the x to close
     --padding-left: 1rem;
@@ -2805,7 +2827,9 @@ body {
   }
 
   .non-map-row {
-    margin-bottom: 0.5em;
+    @media (min-width: 750px) {
+      margin-bottom: 0.5em;
+    }
   }
     
     // .v-row.non-map-row#title-row
@@ -2813,15 +2837,20 @@ body {
     color: var(--accent-color);
     font-weight: bold;
     text-align: right;
-    font-size: 1rem;
+    padding-left: 1rem;
     
-    @media (max-width: 600px){ //SMALL
-      padding-left: 1rem;
+    @media (max-width: 390px){ //TINY
+      font-size: 0.9rem;
     }
-    @media (max-width: 390px){ //SMALL
-      font-size: 0.8rem;
-      padding-left: 1rem;
+
+    @media (max-width: 750px){ //SMALL
+      font-size: 1.1rem;
     }
+
+    @media (min-width: 751px){ //LARGE
+      font-size: 1.3rem;
+    }
+
   }
     
     // .v-row.non-map-row#instructions-row
@@ -2837,6 +2866,16 @@ body {
         padding-inline: 0.7em;
         padding-block: 0.4em; // this plus the margin on p give .7 em on top and bottom
         
+        @media (max-width: 600px){ //SMALL
+          font-size: 0.9rem;
+        }
+        @media (min-width: 601px){ //MEDIUM
+          font-size: 1.1rem;
+        }
+        @media (min-width: 900px){ //LARGE
+          font-size: 1.2rem;
+        }
+
         // span
         .description {
           line-height: 1.4em;
@@ -2846,22 +2885,23 @@ body {
           p {
             margin-block: .3em;
           }
-
         }
       }
     }
   }
 
   #button-row {
+    padding-top: 0.5em;
     align-self: flex-end;
+
     #top-container-buttons{
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    
-    flex-grow: 1;
-    gap: 0.5em;
-          
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+      
+      flex-grow: 1;
+      gap: 0.5em;
+            
       .icon-wrapper {
         background-color: rgba(209, 209, 209, .2);
         border: none;
@@ -2875,8 +2915,9 @@ body {
 
         &.active {
           border: 2px solid var(--sky-color);
-        }
 
+          
+        }
       }
     }
   }
@@ -3005,14 +3046,17 @@ body {
 }
 
 #speed-control {
-  position: absolute;
-  bottom: 6.5rem; // the +1rem aligns it with the switch
-  left: 0.25rem;
-  font-size: .9rem; // all 'em' values are scaled to this
-  --button-width: 2.5em;
-  --button-gap: 0.125em;
-  width: calc(4 * var(--button-width) + 6 * var(--button-gap));
-  pointer-events: auto;
+  display: flex;
+  flex-direction: row;
+  gap: 5px;
+  margin-left: 10px;
+
+  .icon-wrapper {
+    padding-inline: 0.5em;
+    padding-block: 0.6em;
+    border: 2px solid var(--accent-color);
+  }
+
 }
 
 #speed-text {
@@ -3023,7 +3067,13 @@ body {
     padding-inline: 0.4em;
     padding-block: 0.15em;
     border-radius: 0.3em;
-    font-size: 0.9rem;
+
+    @media (max-width: 750px){ //SMALL
+          font-size: 0.9rem;
+        }
+    @media (min-width: 751px){ //LARGE
+          font-size: 1.1rem;
+    }
   }  
 
 #top-wwt-content {
@@ -3056,10 +3106,14 @@ body {
     }
   }
     .v-switch__thumb {
-      color: var(--accent-color);
+      color: #f39d6c;
       background-color: black; 
-      height: 2.1rem;
-      width: 2.2rem;
+
+      @media (min-width: 751px) { //LARGE
+        height: 2.1rem;
+        width: 2.2rem;
+      }
+
     }
 
     .v-input--density-default {
@@ -3071,20 +3125,36 @@ body {
     } 
 
     .v-switch--inset .v-switch__track {
-      height: 2.5rem;
-      width: 4.2rem;
+      @media (min-width: 751px) { //LARGE
+        height: 2.5rem;
+        width: 4.2rem;
+      }
     }
 
     pointer-events: auto;
 
   #top-switches {
     position: absolute;
-    margin-top: 0.7rem;
     right: 0;
+
+    @media (max-width: 750px ) { //SMALL
+      margin-top: 0.5rem;
+    } 
+
+    @media (min-width: 751px ) { //LARGE
+      margin-top: 0.7rem;
+    } 
+
   }
  
   #track-sun-switch {
-    margin-top: 0.7rem;
+    @media (max-width: 750px ) { //SMALL
+      margin-top: 0.5rem;
+    } 
+
+    @media (min-width: 751px ) { //LARGE
+      margin-top: 0.7rem;
+    } 
   }
 }
 

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -71,6 +71,7 @@
               <icon-button
                 :model-value="learnerPath == 'Explore'"
                 fa-icon="rocket"
+                fa-size="xl"
                 :color="accentColor"
                 :focus-color="accentColor"
                 :tooltip-text="'View eclipse from multiple locations'"
@@ -81,6 +82,7 @@
               <icon-button
                 :model-value="learnerPath == 'Answer'"
                 fa-icon="puzzle-piece"
+                fa-size="xl"
                 :color="accentColor"
                 :focus-color="accentColor"
                 :tooltip-text="'Identify eclipse path'"
@@ -91,6 +93,7 @@
               <icon-button
                 :model-value="learnerPath == 'Choose'" 
                 fa-icon="location-dot"
+                fa-size="xl"
                 :color="accentColor"
                 :focus-color="accentColor"
                 :tooltip-text="'Choose any viewing location'"
@@ -101,6 +104,7 @@
               <icon-button
                 v-model="showTextSheet"
                 fa-icon="book-open"
+                fa-size="xl"
                 :color="accentColor"
                 :focus-color="accentColor"
                 :tooltip-text="showTextSheet ? 'Hide Info' : 'Learn More'"
@@ -2984,11 +2988,11 @@ body {
 
   
   @media (max-width: 750px){ //SMALL
-    font-size: 0.7em;    
+    font-size: 1em;    
     }
 
   @media (min-width: 751px){ //LARGE
-      font-size: 1em;
+      font-size: 1.1em;
   }
 
   .v-list-item__prepend {
@@ -3019,13 +3023,13 @@ body {
         
     @media (max-width: 750px){ //SMALL
       .v-btn--size-default {
-      font-size: 0.3em;
+      font-size: 0.8em;
       }  
     }
 
     @media (min-width: 751px){ //LARGE
       .v-btn--size-default {
-      font-size: 0.8em;
+      font-size: 0.9em;
       }    
     }
 

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -1065,7 +1065,6 @@ export default defineComponent({
       showAltAzGrid: true,
       showHorizon: true,
       showEcliptic: false, 
-      showInfoSheet: false,   
       
       toggleTrackSun: true,
       
@@ -1271,14 +1270,14 @@ export default defineComponent({
       const todMs = 1000 * (3600 * dateForTOD.getUTCHours() + 60 * dateForTOD.getUTCMinutes() + dateForTOD.getUTCSeconds());
       return todMs / MILLISECONDS_PER_DAY;
     },
-    // showInfoSheet: {
-    //   get(): boolean {
-    //     return this.sheet === 'text';
-    //   },
-    //   set(_value: boolean) {
-    //     this.selectSheet('text');
-    //   }
-    // },
+    showInfoSheet: {
+      get(): boolean {
+        return this.sheet === 'text';
+      },
+      set(_value: boolean) {
+        this.selectSheet('text');
+      }
+    },
 
     locationDeg: {
       get(): LocationDeg {

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -210,63 +210,59 @@
           @keyup.enter="showInfoSheet = false"
           tabindex="0"
         ></font-awesome-icon>
-        <v-window v-model="tab" id="tab-items" class="pa-2 no-bottom-border-radius">
-          <v-window-item>
-            <v-card class="no-bottom-border-radius scrollable">
-              <v-card-text class="info-text no-bottom-border-radius">
-                <v-row>
-                <v-col cols="6" id="info-text-box">
-                  <div id="main-info-text">
+        <v-card class="no-bottom-border-radius scrollable">
+          <v-card-text class="info-text no-bottom-border-radius">
+            <v-row>
+            <v-col cols="6" id="info-text-box">
+              <div id="main-info-text">
+                <p>
+                Get ready, North America, for not one, but two solar eclipses! On October 14, 2023, North, Central, and South America will be treated to a beautiful annular eclipse. Only 6 months later, on April 8, 2024, an awe-inspiring total solar eclipse will stretch from coast-to-coast across the United States and Canada.
+                </p>
+                <p>
+                This interactive lets you explore the October "Ring of Fire" eclipse from different locations. 
+                </p>
+                <p id="safety-warning">
+                  SAFETY FIRST: NEVER look directly at the Sun without proper eye protection.
+                </p>
+              </div>  
+                <div id="FAQ">
+                  <details>
+                    <summary>
+                      What causes Solar Eclipses?
+                    </summary>
                     <p>
-                    Get ready, North America, for not one, but two solar eclipses! On October 14, 2023, North, Central, and South America will be treated to a beautiful annular eclipse. Only 6 months later, on April 8, 2024, an awe-inspiring total solar eclipse will stretch from coast-to-coast across the United States and Canada.
+                      A solar eclipse happens when the Moon passes between the Earth and the Sun and blocks the Sun from our view. Partial eclipses occur about every 6 months, somewhere on the Earth. The U.S. is lucky to be in the path of the next two solar eclipses. 
                     </p>
+                  </details>
+                  
+                  <details>
+                    <summary> Total vs. Annular Eclipse</summary>
                     <p>
-                    This interactive lets you explore the October "Ring of Fire" eclipse from different locations. 
+                      During a total eclipse, the Moon covers the entire face of the Sun. Because the Moon doesn't orbit the Earth in a perfect circle, sometimes it is farther away from Earth and appears smaller. When this happens, the Moon doesn't cover the entire face of the Sun, and during the eclipse we can still see a bright ring of light around the Moon. This is called an Annular Eclipse.
                     </p>
-                    <p id="safety-warning">
-                      SAFETY FIRST: NEVER look directly at the Sun without proper eye protection.
+                  </details>
+                  
+                  <details> 
+                    <summary> Why can only some places see the eclipse?</summary>
+                    <p>
+                      An eclipse is caused by the Moon casting a shadow on the Earth. People who are directly behind the Moon will see an annular or total eclipse. As the Moon moves in its orbit around Earth, and as Earth rotates, the location of the shadow will move, sweeping out a path across the surface of the Earth. For a larger number of people who are not directly behind the moon, a smaller amount of the Sun will be blocked, causing a partial eclipse. Even further outside the shadow the Sun will not be blocked at all, and there will be no eclipse visible.
                     </p>
-                  </div>  
-                    <div id="FAQ">
-                      <details>
-                        <summary>
-                          What causes Solar Eclipses?
-                        </summary>
-                        <p>
-                          A solar eclipse happens when the Moon passes between the Earth and the Sun and blocks the Sun from our view. Partial eclipses occur about every 6 months, somewhere on the Earth. The U.S. is lucky to be in the path of the next two solar eclipses. 
-                        </p>
-                      </details>
-                      
-                      <details>
-                        <summary> Total vs. Annular Eclipse</summary>
-                        <p>
-                          During a total eclipse, the Moon covers the entire face of the Sun. Because the Moon doesn't orbit the Earth in a perfect circle, sometimes it is farther away from Earth and appears smaller. When this happens, the Moon doesn't cover the entire face of the Sun, and during the eclipse we can still see a bright ring of light around the Moon. This is called an Annular Eclipse.
-                        </p>
-                      </details>
-                      
-                      <details> 
-                        <summary> Why can only some places see the eclipse?</summary>
-                        <p>
-                          An eclipse is caused by the Moon casting a shadow on the Earth. People who are directly behind the Moon will see an annular or total eclipse. As the Moon moves in its orbit around Earth, and as Earth rotates, the location of the shadow will move, sweeping out a path across the surface of the Earth. For a larger number of people who are not directly behind the moon, a smaller amount of the Sun will be blocked, causing a partial eclipse. Even further outside the shadow the Sun will not be blocked at all, and there will be no eclipse visible.
-                        </p>
-                        <p> 
-                          The figure shows the parts of Earth that are directly behind the Moon (in the darkest shadow) and partially behind the moon (in the lighter shadow).
-                        </p> 
-                      </details>
-                    </div>
-                </v-col>
-                <v-col cols="6">
-                  <figure>
-                    <!-- <v-img src="https://www.nasa.gov/sites/default/files/thumbnails/image/tsis_eclipse-1.gif"></v-img> -->
-                    <gif-play-pause startPaused :gif='require("./assets/eclipse.gif")' :still='require("./assets/eclipse_static.gif")' alt="Cartoon of a Solar Eclipse"/>
-                    <figcaption>Image credit: NASA Goddard / Katy Mersmann</figcaption>
-                  </figure>
-                </v-col>
-              </v-row>
-              </v-card-text>
-            </v-card>
-          </v-window-item>
-        </v-window>
+                    <p> 
+                      The figure shows the parts of Earth that are directly behind the Moon (in the darkest shadow) and partially behind the moon (in the lighter shadow).
+                    </p> 
+                  </details>
+                </div>
+            </v-col>
+            <v-col cols="6">
+              <figure>
+                <!-- <v-img src="https://www.nasa.gov/sites/default/files/thumbnails/image/tsis_eclipse-1.gif"></v-img> -->
+                <gif-play-pause startPaused :gif='require("./assets/eclipse.gif")' :still='require("./assets/eclipse_static.gif")' alt="Cartoon of a Solar Eclipse"/>
+                <figcaption>Image credit: NASA Goddard / Katy Mersmann</figcaption>
+              </figure>
+            </v-col>
+          </v-row>
+          </v-card-text>
+        </v-card>
       </v-card>
     </v-dialog>
     
@@ -279,7 +275,7 @@
       :style="cssVars"
     >
       <v-card
-        id="wwt-sheet-card">
+        class="bottom-sheet-card">
         <v-tabs
           v-model="tab"
           height="32px"
@@ -300,64 +296,60 @@
           @keyup.enter="showWWTGuideSheet = false"
           tabindex="0"
         ></font-awesome-icon>
-        <v-window v-model="tab" id="tab-items" class="pa-2 no-bottom-border-radius">
-          <v-window-item>
-            <v-card class="no-bottom-border-radius scrollable">
-              <v-card-text class="info-text no-bottom-border-radius">
-                <v-container>
-                  <v-row align="center">
-                  <v-col cols="4">
-                      <v-chip
-                        label
-                        outlined
-                      >
-                        Pan
-                      </v-chip>
-                    </v-col>
-                    <v-col cols="8" class="pt-1">
-                      <strong>{{ touchscreen ? "press + drag" : "click + drag" }}</strong>  {{ touchscreen ? ":" : "or" }}  <strong>{{ touchscreen ? ":" : "W-A-S-D" }}</strong> {{ touchscreen ? ":" : "keys" }}<br>
-                    </v-col>
-                  </v-row>
-                  <v-row align="center">
-                    <v-col cols="4">
-                      <v-chip
-                        label
-                        outlined
-                      >
-                        Zoom
-                      </v-chip>
-                    </v-col>
-                    <v-col cols="8" class="pt-1">
-                      <strong>{{ touchscreen ? "pinch in and out" : "scroll in and out" }}</strong> {{ touchscreen ? ":" : "or" }} <strong>{{ touchscreen ? ":" : "I-O" }}</strong> {{ touchscreen ? ":" : "keys" }}<br>
-                    </v-col>
-                  </v-row>
-                  <v-row>
-                    <v-col cols="12">
-                      <div class="credits">
-                      <h3>Credits:</h3>
-                      <h4><a href="https://www.cosmicds.cfa.harvard.edu/" target="_blank" rel="noopener noreferrer">CosmicDS</a> Mini Stories Team:</h4>
-                      Pat Udomprasert<br>
-                      Jon Carifio<br>
-                      John Lewis<br>
-                      Alyssa Goodman<br>
-                      Mary Dussault<br>
-                      Harry Houghton<br>
-                      Anna Nolin<br>
-                      Evaluator: Sue Sunbury<br>
-                      <br>
-                      <h4>WorldWide Telescope Team:</h4>
-                      Peter Williams<br>
-                      A. David Weigel<br>
-                      Jon Carifio<br>
-                      </div>
-                      <v-spacer class="end-spacer"></v-spacer>
-                    </v-col>
-                  </v-row>
-                </v-container>              
-              </v-card-text>
-            </v-card>
-          </v-window-item>
-        </v-window>
+        <v-card class="no-bottom-border-radius scrollable">
+          <v-card-text class="info-text no-bottom-border-radius">
+            <v-container>
+              <v-row align="center">
+              <v-col cols="4">
+                  <v-chip
+                    label
+                    outlined
+                  >
+                    Pan
+                  </v-chip>
+                </v-col>
+                <v-col cols="8" class="pt-1">
+                  <strong>{{ touchscreen ? "press + drag" : "click + drag" }}</strong>  {{ touchscreen ? ":" : "or" }}  <strong>{{ touchscreen ? ":" : "W-A-S-D" }}</strong> {{ touchscreen ? ":" : "keys" }}<br>
+                </v-col>
+              </v-row>
+              <v-row align="center">
+                <v-col cols="4">
+                  <v-chip
+                    label
+                    outlined
+                  >
+                    Zoom
+                  </v-chip>
+                </v-col>
+                <v-col cols="8" class="pt-1">
+                  <strong>{{ touchscreen ? "pinch in and out" : "scroll in and out" }}</strong> {{ touchscreen ? ":" : "or" }} <strong>{{ touchscreen ? ":" : "I-O" }}</strong> {{ touchscreen ? ":" : "keys" }}<br>
+                </v-col>
+              </v-row>
+              <v-row>
+                <v-col cols="12">
+                  <div class="credits">
+                  <h3>Credits:</h3>
+                  <h4><a href="https://www.cosmicds.cfa.harvard.edu/" target="_blank" rel="noopener noreferrer">CosmicDS</a> Mini Stories Team:</h4>
+                  Pat Udomprasert<br>
+                  Jon Carifio<br>
+                  John Lewis<br>
+                  Alyssa Goodman<br>
+                  Mary Dussault<br>
+                  Harry Houghton<br>
+                  Anna Nolin<br>
+                  Evaluator: Sue Sunbury<br>
+                  <br>
+                  <h4>WorldWide Telescope Team:</h4>
+                  Peter Williams<br>
+                  A. David Weigel<br>
+                  Jon Carifio<br>
+                  </div>
+                  <v-spacer class="end-spacer"></v-spacer>
+                </v-col>
+              </v-row>
+            </v-container>              
+          </v-card-text>
+        </v-card>
       </v-card>
     </v-dialog>
 

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -490,7 +490,7 @@
     </v-dialog>
   
   <div id="top-wwt-content">
-      <div id="location-time-display">
+      <div id="location-date-display">
         <v-chip 
           prepend-icon="mdi-map-marker-radius"
           variant="outlined"
@@ -521,7 +521,6 @@
               v-bind="props"
               id="viewer-mode-switch"
               >
-              
               <v-switch
                 inset
                 hide-details
@@ -590,7 +589,7 @@
               :color="accentColor"
               v-model="showAltAzGrid"
               @keyup.enter="showAltAzGrid = !showAltAzGrid"
-              label="Grid"
+              label="Sky Grid"
               hide-details 
             />
             <v-checkbox
@@ -611,7 +610,7 @@
               :color="accentColor"
               v-model="useRegularMoon"
               @keyup.enter="useRegularMoon = !useRegularMoon"
-              label="Bright Moon"
+              label="Visible Moon"
               hide-details
             />
           </div>
@@ -1046,7 +1045,7 @@ export default defineComponent({
       moonColor: "#CFD8DC",
       guidedContentHeight: "300px",
       showGuidedContent: true,
-      inIntro: true,
+      inIntro: false,
 
       tab: 0,
       introSlide: 1,
@@ -2258,16 +2257,7 @@ body {
 
 // these are now in #top-content
 
-#track-sun-switch {
-  // position: absolute;
-  // top: 1rem;
-  // left: 6rem;
-  pointer-events: auto;
-  .v-switch__thumb {
-    color: var(--accent-color);
-    background-color: black; 
-  }
-}
+
 
 
 #share-button-wrapper {
@@ -2357,9 +2347,16 @@ body {
   pointer-events: auto;
 
   .v-label {
-    font-size: 0.8em;
     color: var(--comet-color);
     opacity: 1;
+
+    @media (max-width: 500px){ //SMALL
+      font-size: 0.8em;
+    }
+
+    @media (min-width: 501px){ //LARGE
+      font-size: 1.1em;
+    }
   }
 
   #control-checkboxes {
@@ -2378,7 +2375,7 @@ body {
 
     @media (min-width: 751px){ //LARGE
       .v-checkbox .v-selection-control {
-      height: 2em !important;
+      height: 2.1em !important;
       min-height: 1em !important;
       }
     }
@@ -3016,79 +3013,6 @@ body {
   --button-gap: 0.125em;
   width: calc(4 * var(--button-width) + 6 * var(--button-gap));
   pointer-events: auto;
-  
-  
-  .speed-control-buttons-container {
-    position: relative;
-    
-    //    BUTTON LAYOUT    //
-    .speed-control-button {
-      margin-inline: var(--button-gap);
-    }
-    
-    .speed-control-button:first-child {
-      margin-inline-start: 0;
-    }
-    
-    .speed-control-button:last-child {
-      margin-inline-end: 0;
-    }
-    
-    // create buttons which center their inner content
-    .speed-control-button {
-      position: relative;
-      display: inline-block; // 'block' to put in a column
-      width: var(--button-width);
-      height: var(--button-width);
-      
-      > * {
-        position: absolute;
-        top: 50%;
-        left: 50%;
-        transform: translate(-50%, -50%);
-      }
-    }
-  
-    //     STYLING     //
-    .speed-control-button {
-      border-radius: 50%;
-      border: 0.125em solid var(--accent-color);
-      background-color: rgba(0, 0, 0, 0.5);
-
-      
-      > * { // all direct children (the inner content)
-        color: var(--accent-color);
-      }
-      
-      // text button
-      #speed-text-now {
-        font-size: 0.6em;
-        font-weight: bold;
-      }
-      
-      // text button
-      #speed-text-one-x {
-        font-size: 1em;
-        font-weight: bold;
-      }
-      
-      // text button
-      #speed-text-reset {
-        font-size: 2em;
-        font-weight: bold;
-      }
-      
-    }
-    
-    .speed-control-button:active {
-      background-color: #8e3b0b; // hsl sdarker version of accent-color
-    }
-    
-  
-  } 
-
-
-  
 }
 
 #speed-text {
@@ -3107,25 +3031,35 @@ body {
   top: 0.5rem;
   right: 0.5rem;
 
-  #location-time-display  {
+  #location-date-display  {
   
     display: flex;
     justify-content: flex-end;
     flex-wrap: column;
     gap:5px;
 
-      .v-chip {
-        border: none;
-        color: blue;
-        background-color: white;
-        font-size: 0.8em;
-        opacity: 0.9;
+    .v-chip {
+      border: none;
+      color: blue;
+      background-color: white;
+      opacity: 0.9;
+
+      @media (max-width: 750px){ //SMALL
+        font-size: 1em;
+        padding: 1em;
+      }
+
+      @media (min-width: 751px){ //LARGE
+        font-size: 1.1em;
+        padding: 1.1em;
       }
     }
-  
+  }
     .v-switch__thumb {
       color: var(--accent-color);
       background-color: black; 
+      height: 2.1rem;
+      width: 2.2rem;
     }
 
     .v-input--density-default {
@@ -3136,16 +3070,21 @@ body {
       --v-selection-control-size: auto;
     } 
 
+    .v-switch--inset .v-switch__track {
+      height: 2.5rem;
+      width: 4.2rem;
+    }
+
     pointer-events: auto;
 
   #top-switches {
     position: absolute;
-    margin-top: 0.5rem;
+    margin-top: 0.7rem;
     right: 0;
   }
-
+ 
   #track-sun-switch {
-    margin-top: 0.5rem;
+    margin-top: 0.7rem;
   }
 }
 

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -204,42 +204,44 @@
             <v-card class="no-bottom-border-radius scrollable">
               <v-card-text class="info-text no-bottom-border-radius">
                 <v-row>
-                <v-col id="FAQ" cols="6">
+                <v-col cols="6">
+                  <div id="main-info-text">
                     Get ready North America for not one, but two brilliant solar eclipses! 
                     First, a dazzling annular or <i>Ring of Fire</i> eclipse on October 14, 2023. Only 6 months late, on April 8, 2024,
                     get ready for an awe-inspiring solar eclipse which stretches from coast-to-coast across the United States.
                     This interactive lets you explore the October "Ring of Fire" eclipse from different locations.    
-                    
-                    <details>
-                      <summary>
-                        What causes Solar Eclipses? ☀️🌕🌎
-                      </summary>
-                    <p>A solar eclipse happens when the Moon passes between the Earth and the Sun and blocks the Sun from our view.
-                      Partial eclipses occur about every 6 months somewhere on the Earth (Can you think of WHY this is?). The U.S. is lucky 
-                      to be in the path of the next two solara eclipses. 
-                      </p>
-                    </details>
-                    
-                    <details>
-                      <summary> Total vs. Annular Eclipse</summary>
-                      <p>
-                        During a Total Eclipse, the Moon covers the entire face of the Sun. Because the Moon doesn't orbit the Earth
-                        in a perfect circle, sometimes it is farther away from the Earth and appears smaller. When this happens, the Moon
-                        doesn't cover the entire face of the Sun, and during the eclipse we can still see a ring of light around the Moon. This is called an Annular Eclipse.
-                      </p>
-                    </details>
-                    
-                    <details> 
-                      <summary> Why can only some places see the eclipse? 🌒</summary>
-                      <p>
-                        An eclipse is caused by the Moon casting a shadow on the Earth. 
-                        People who are directly behind the Moon are in the darkest part of the shadow, and will see an annular (Oct) or total (Apr) eclipse. 
-                        As the Moon moves in its orbit around the Earth, the location of the shadow will move, sweeping out a path across the surface of the Earth. 
-                        For a larger number of people, those not directly behind the moon, the Sun will only be partially blocked, causing a partial eclipse. Even further outside the shadow
-                        the Sun will not be blocked at all, and there will be no eclipse visible. 
-                      </p> 
-                    </details>
-                    
+                  </div>  
+                    <div id="FAQ">
+                      <details>
+                        <summary>
+                          What causes Solar Eclipses? ☀️🌕🌎
+                        </summary>
+                      <p>A solar eclipse happens when the Moon passes between the Earth and the Sun and blocks the Sun from our view.
+                        Partial eclipses occur about every 6 months somewhere on the Earth (Can you think of WHY this is?). The U.S. is lucky 
+                        to be in the path of the next two solara eclipses. 
+                        </p>
+                      </details>
+                      
+                      <details>
+                        <summary> Total vs. Annular Eclipse</summary>
+                        <p>
+                          During a Total Eclipse, the Moon covers the entire face of the Sun. Because the Moon doesn't orbit the Earth
+                          in a perfect circle, sometimes it is farther away from the Earth and appears smaller. When this happens, the Moon
+                          doesn't cover the entire face of the Sun, and during the eclipse we can still see a ring of light around the Moon. This is called an Annular Eclipse.
+                        </p>
+                      </details>
+                      
+                      <details> 
+                        <summary> Why can only some places see the eclipse? 🌒</summary>
+                        <p>
+                          An eclipse is caused by the Moon casting a shadow on the Earth. 
+                          People who are directly behind the Moon are in the darkest part of the shadow, and will see an annular (Oct) or total (Apr) eclipse. 
+                          As the Moon moves in its orbit around the Earth, the location of the shadow will move, sweeping out a path across the surface of the Earth. 
+                          For a larger number of people, those not directly behind the moon, the Sun will only be partially blocked, causing a partial eclipse. Even further outside the shadow
+                          the Sun will not be blocked at all, and there will be no eclipse visible. 
+                        </p> 
+                      </details>
+                    </div>
                 </v-col>
                 <v-col cols="6">
                   <figure>
@@ -1042,7 +1044,8 @@ export default defineComponent({
 
       showAltAzGrid: true,
       showHorizon: true,
-      showEcliptic: false,    
+      showEcliptic: false, 
+      showTextSheet: true,   
       
       toggleTrackSun: true,
       
@@ -1248,14 +1251,14 @@ export default defineComponent({
       const todMs = 1000 * (3600 * dateForTOD.getUTCHours() + 60 * dateForTOD.getUTCMinutes() + dateForTOD.getUTCSeconds());
       return todMs / MILLISECONDS_PER_DAY;
     },
-    showTextSheet: {
-      get(): boolean {
-        return this.sheet === 'text';
-      },
-      set(_value: boolean) {
-        this.selectSheet('text');
-      }
-    },
+    // showTextSheet: {
+    //   get(): boolean {
+    //     return this.sheet === 'text';
+    //   },
+    //   set(_value: boolean) {
+    //     this.selectSheet('text');
+    //   }
+    // },
 
     locationDeg: {
       get(): LocationDeg {
@@ -2578,7 +2581,12 @@ body {
 
 
 .bottom-sheet {
-  
+
+  #main-info-text {
+    padding-inline: 0.5em;
+  }
+
+
   figure {
     position: sticky;
     top: 0;
@@ -2594,29 +2602,28 @@ body {
   }
   
   #FAQ{
-  
+    margin-top: 1em;
+
     details {
-      font-size: 1em;
-      padding: 0.5em;
+      padding-block: 0.7em;
+      padding-inline: 1.2em;
       height: fit-content;
-      margin-block: 0.5em;
-      border-top-left-radius: 0.5em;
+      border-radius: 0;
       background-color: #486273;
       
       summary {
         font-weight: bold;
-        font-size: 1em;
+        font-size: ~"max(15px, calc(0.7em + 0.3vw))";
         cursor: pointer;
       }
       
       p {
-        font-size: 0.9em;
-        padding: 0.5em;
+        font-size: ~"max(15px, calc(0.7em + 0.3vw))";
+        line-height: ~"max(18px, calc(0.9em + 0.4vw))";
+        padding-top: 0.5em;
+        padding-inline: 1em;
       }
-      
-      &[open] {
-        border-bottom-left-radius: 0.5em;
-      }
+    
     }
   }
   
@@ -2677,17 +2684,22 @@ body {
   #tab-items {
     // padding-bottom: 2px !important;
 
+    .h3 {
+      font-size: ~"max(16px, calc(0.9em + 0.4vw))";
+    }
+
     .v-card-text {
-      font-size: ~"max(14px, calc(0.7em + 0.3vw))";
-      padding-top: ~"max(2vw, 16px)";
-      padding-left: ~"max(4vw, 16px)";
-      padding-right: ~"max(4vw, 16px)";
+      font-size: ~"max(14px, calc(0.8em + 0.4vw))";
+      line-height: ~"max(18px, calc(1em + 0.5vw))";
+
+      // padding-top: ~"max(2vw, 16px)";
+      // padding-left: ~"max(4vw, 16px)";
+      // padding-right: ~"max(4vw, 16px)";
 
       .end-spacer {
         height: 25px;
       }
     }
-
   }
 
   #close-text-icon {

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -82,17 +82,6 @@
                 @activate="() => { learnerPath = 'Explore'}"
               ></icon-button>
               <icon-button
-                :model-value="learnerPath == 'Answer'"
-                fa-icon="puzzle-piece"
-                fa-size="xl"
-                :color="accentColor"
-                :focus-color="accentColor"
-                :tooltip-text="'Identify eclipse path'"
-                :tooltip-location="'bottom'"
-                :box-shadow="false"
-                @activate="() => { learnerPath = 'Answer'}"
-              ></icon-button>   
-              <icon-button
                 :model-value="learnerPath == 'Choose'" 
                 fa-icon="location-dot"
                 fa-size="xl"
@@ -103,6 +92,17 @@
                 :box-shadow="false"
                 @activate="() => { learnerPath = 'Choose'}"
               ></icon-button>
+              <icon-button
+                :model-value="learnerPath == 'Answer'"
+                fa-icon="puzzle-piece"
+                fa-size="xl"
+                :color="accentColor"
+                :focus-color="accentColor"
+                :tooltip-text="'Identify eclipse path'"
+                :tooltip-location="'bottom'"
+                :box-shadow="false"
+                @activate="() => { learnerPath = 'Answer'}"
+              ></icon-button>   
               <icon-button
                 v-model="showInfoSheet"
                 fa-icon="book-open"
@@ -434,15 +434,17 @@
         <v-window v-model="introSlide">
           <v-window-item :value="1">
             <div class="intro-text">
-              <p>
+              <p class="mb-5">
               On October 14, 2023, the Americas will experience
               a partial solar eclipse, where the Moon 
               will appear to travel across the Sun and 
               block a portion of it.
               </p>
-            <br />
-              <p>
+              <p  class="mb-5">
               A lucky segment of the U.S., Central, and South America will experience a dazzling <b>"Ring of Fire"</b> created by an <b>annular eclipse</b>.
+              </p>
+              <p class="mb-5">
+              Use your detective skills to identify where those lucky people are in our map quiz.
               </p>
             </div>
           </v-window-item>
@@ -465,7 +467,7 @@
                   <template v-slot:prepend>
                     <font-awesome-icon icon="puzzle-piece" size="xl" class="bullet-icon"></font-awesome-icon>
                   </template>
-                    Use some detective work to identify the Path of Visibility in the U.S. for the annular eclipse
+                    Identify the Path of Visibility in the U.S. for the annular eclipse in our map quiz
                 </v-list-item>
                 <v-list-item>
                   <template v-slot:prepend>
@@ -478,6 +480,12 @@
                     <font-awesome-icon icon="book-open" size="xl" class="bullet-icon"></font-awesome-icon>
                   </template>
                     Learn more about solar eclipses 
+                </v-list-item>
+                <v-list-item>
+                  <template v-slot:prepend>
+                    <font-awesome-icon icon="computer-mouse" size="xl" class="bullet-icon"></font-awesome-icon>
+                  </template>
+                    Learn more about how to navigate this app 
                 </v-list-item>
               </ul>
             </div>
@@ -1070,7 +1078,7 @@ export default defineComponent({
       moonColor: "#CFD8DC",
       guidedContentHeight: "300px",
       showGuidedContent: true,
-      inIntro: false, //FIX
+      inIntro: true, //FIX
 
       tab: 0,
       introSlide: 1,

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -45,7 +45,8 @@
             <!-- Learn Path -->
             <div class="instructions-text" v-if="learnerPath=='Explore'">
               <span class="description">
-                <p>Click the highlighted cities to view the eclipse from other locations.</p>
+                <p>Click <font-awesome-icon icon="play" size="l" class="bullet-icon"/> to "watch" the eclipse in Albuquerque, NM.</p>
+                <p>Click highlighted cities on the map to switch locations and view the eclipse from there.</p>
                 <p>Explore until you can identify which locations will see an annular eclipse.</p>
               </span>
             </div>
@@ -1046,7 +1047,7 @@ export default defineComponent({
       showAltAzGrid: true,
       showHorizon: true,
       showEcliptic: false, 
-      showTextSheet: true,   
+      showTextSheet: false,   
       
       toggleTrackSun: true,
       
@@ -2965,6 +2966,10 @@ body {
   }
 }
 
+.bullet-icon {
+  color: var(--accent-color)
+}
+
 #introduction-overlay {
   position: absolute;
   top: 50%;
@@ -2997,10 +3002,6 @@ body {
   
   .intro-text {
     color: white;
-
-    .bullet-icon {
-      color: var(--accent-color)
-    }
   }
   
   div#intro-bottom-controls {

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -187,8 +187,8 @@
           dense
           grow
         >
-          <v-tab tabindex="0"><h3>Information</h3></v-tab>
-          <v-tab tabindex="0"><h3>Using WWT</h3></v-tab>
+          <v-tab tabindex="0"><h3 class="tab-title">Information</h3></v-tab>
+          <v-tab tabindex="0"><h3 class="tab-title">Using WWT</h3></v-tab>
         </v-tabs>
         <font-awesome-icon
           id="close-text-icon"
@@ -204,17 +204,19 @@
             <v-card class="no-bottom-border-radius scrollable">
               <v-card-text class="info-text no-bottom-border-radius">
                 <v-row>
-                <v-col cols="6">
+                <v-col cols="6" id="info-text-box">
                   <div id="main-info-text">
+                    <p>
                     Get ready North America for not one, but two brilliant solar eclipses! 
                     First, a dazzling annular or <i>Ring of Fire</i> eclipse on October 14, 2023. Only 6 months late, on April 8, 2024,
                     get ready for an awe-inspiring solar eclipse which stretches from coast-to-coast across the United States.
-                    This interactive lets you explore the October "Ring of Fire" eclipse from different locations.    
+                    This interactive lets you explore the October "Ring of Fire" eclipse from different locations.
+                    </p>
                   </div>  
                     <div id="FAQ">
                       <details>
                         <summary>
-                          What causes Solar Eclipses? ☀️🌕🌎
+                          What causes Solar Eclipses?
                         </summary>
                       <p>A solar eclipse happens when the Moon passes between the Earth and the Sun and blocks the Sun from our view.
                         Partial eclipses occur about every 6 months somewhere on the Earth (Can you think of WHY this is?). The U.S. is lucky 
@@ -232,7 +234,7 @@
                       </details>
                       
                       <details> 
-                        <summary> Why can only some places see the eclipse? 🌒</summary>
+                        <summary> Why can only some places see the eclipse?</summary>
                         <p>
                           An eclipse is caused by the Moon casting a shadow on the Earth. 
                           People who are directly behind the Moon are in the darkest part of the shadow, and will see an annular (Oct) or total (Apr) eclipse. 
@@ -2582,10 +2584,41 @@ body {
 
 .bottom-sheet {
 
+  .tab-title {
+    font-size: ~"max(18px, calc(1.1em + 0.3vw))";
+  }
+
+  #info-text-box {
+    font-size: ~"max(16px, calc(1em + 0.3vw))";
+    line-height: ~"max(20px, calc(1.1em + 0.4vw))";
+  }
   #main-info-text {
     padding-inline: 0.5em;
   }
+  
+  #FAQ{
+    margin-top: 1em;
 
+    details {
+      padding-block: 0.7em;
+      padding-inline: 1.2em;
+      height: fit-content;
+      background-color: #486273;
+      
+      summary {
+        font-weight: bold;
+        font-size: ~"max(16px, calc(0.8em + 0.3vw))";
+        cursor: pointer;
+      }
+      
+      p {
+
+        padding-top: 0.5em;
+        padding-inline: 1em;
+      }
+    
+    }
+  }
 
   figure {
     position: sticky;
@@ -2600,34 +2633,6 @@ body {
       padding-inline: 10px 5px;
     }
   }
-  
-  #FAQ{
-    margin-top: 1em;
-
-    details {
-      padding-block: 0.7em;
-      padding-inline: 1.2em;
-      height: fit-content;
-      border-radius: 0;
-      background-color: #486273;
-      
-      summary {
-        font-weight: bold;
-        font-size: ~"max(15px, calc(0.7em + 0.3vw))";
-        cursor: pointer;
-      }
-      
-      p {
-        font-size: ~"max(15px, calc(0.7em + 0.3vw))";
-        line-height: ~"max(18px, calc(0.9em + 0.4vw))";
-        padding-top: 0.5em;
-        padding-inline: 1em;
-      }
-    
-    }
-  }
-  
-
   
   .v-overlay__content {
     align-self: center;
@@ -2680,27 +2685,7 @@ body {
     // border-bottom-right-radius: 0px !important;
     width: auto;
   }
-
-  #tab-items {
-    // padding-bottom: 2px !important;
-
-    .h3 {
-      font-size: ~"max(16px, calc(0.9em + 0.4vw))";
-    }
-
-    .v-card-text {
-      font-size: ~"max(14px, calc(0.8em + 0.4vw))";
-      line-height: ~"max(18px, calc(1em + 0.5vw))";
-
-      // padding-top: ~"max(2vw, 16px)";
-      // padding-left: ~"max(4vw, 16px)";
-      // padding-right: ~"max(4vw, 16px)";
-
-      .end-spacer {
-        height: 25px;
-      }
-    }
-  }
+  
 
   #close-text-icon {
     position: absolute;

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -200,7 +200,6 @@
           grow
         >
           <v-tab tabindex="0"><h3 class="tab-title">Information</h3></v-tab>
-          <v-tab tabindex="0"><h3 class="tab-title">Using WWT</h3></v-tab>
         </v-tabs>
         <font-awesome-icon
           id="close-text-icon"
@@ -267,6 +266,41 @@
               </v-card-text>
             </v-card>
           </v-window-item>
+        </v-window>
+      </v-card>
+    </v-dialog>
+    
+    <v-dialog
+      scrim="false"
+      transition="slide-y-transition"
+      v-model="showWWTGuideSheet" 
+      class='bottom-sheet'
+      id="wwt-guide-sheet"
+      :style="cssVars"
+    >
+      <v-card
+        id="wwt-sheet-card">
+        <v-tabs
+          v-model="tab"
+          height="32px"
+          :color="accentColor"
+          :slider-color="accentColor"
+          id="tabs"
+          dense
+          grow
+        >
+          <v-tab tabindex="0"><h3 class="tab-title">Using WWT</h3></v-tab>
+        </v-tabs>
+        <font-awesome-icon
+          id="close-text-icon"
+          class="control-icon"
+          icon="times"
+          size="lg"
+          @click="showWWTGuideSheet = false"
+          @keyup.enter="showWWTGuideSheet = false"
+          tabindex="0"
+        ></font-awesome-icon>
+        <v-window v-model="tab" id="tab-items" class="pa-2 no-bottom-border-radius">
           <v-window-item>
             <v-card class="no-bottom-border-radius scrollable">
               <v-card-text class="info-text no-bottom-border-radius">
@@ -926,6 +960,8 @@ export default defineComponent({
       showMapSelector: false,
       showLocationSelector: false,
 
+      showWWTGuideSheet: false,
+      
       selectionProximity: 4,
       pointerMoveThreshold: 6,
       isPointerMoving: false,
@@ -2598,7 +2634,10 @@ body {
   }
 }
 
-
+#wwt-sheet-card {
+  width: 50%;
+  align-self: center;
+}
 
 .bottom-sheet {
 

--- a/annular-eclipse-2023/src/main.ts
+++ b/annular-eclipse-2023/src/main.ts
@@ -46,6 +46,7 @@ import {
   faMountainSun,
   faShareNodes,
   faSquareXmark,
+  faComputerMouse,
 } from "@fortawesome/free-solid-svg-icons";
 
 library.add(faBookOpen);
@@ -69,6 +70,7 @@ library.add(faArrowsRotate);
 library.add(faMountainSun);
 library.add(faShareNodes);
 library.add(faSquareXmark);
+library.add(faComputerMouse);
 
 /** v-hide directive taken from https://www.ryansouthgate.com/2020/01/30/vue-js-v-hide-element-whilst-keeping-occupied-space/ */
 // Extract the function out, up here, so I'm not writing it twice


### PR DESCRIPTION
This builds on both #224 and #225, so merge both of those first.

This edits the text everywhere to create a more cohesive experience for the user.

I'd like to move the WWT instructions into its own window, so the user doesn't have to click 2 buttons to get there. @johnarban, can you please update the code so the WWT instructions appear when the user clicks the computer-mouse icon that I added? (I'm open to using other icons).  (So the idea is that instead of both sets of instructions being on 2 tabs activated by the book icon, each will appear on their own card.)