### PR TITLE
Add overlay for sun/moon intersection

### DIFF
--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -1392,7 +1392,7 @@ export default defineComponent({
     createMoonOverlay() {
 
       // Don't draw an overlay if we're using the regular WWT moon image
-      if (this.useRegularMoon) {
+      if (this.useRegularMoon || this.viewerMode === 'SunScope') {
         return;
       }
 

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -1916,13 +1916,13 @@ export default defineComponent({
         this.removeAnnotations();
       }
       finally {
+        this.createMoonOverlay();
         if (this.showHorizon) {
           this.createHorizon(when);
           if (this.showSky) {
             this.createSky(when);
           }
         }
-        this.createMoonOverlay();
       }
     },
 

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -1390,6 +1390,12 @@ export default defineComponent({
     },
 
     createMoonOverlay() {
+
+      // Don't draw an overlay if we're using the regular WWT moon image
+      if (this.useRegularMoon) {
+        return;
+      }
+
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       const canvasHeight: number = this.wwtControl.canvas.height;
@@ -1537,7 +1543,7 @@ export default defineComponent({
       const locations = points.map(pt => this.findRADecForScreenPoint({ x: pt.x, y: canvasHeight - pt.y }));
       const overlay = new Poly2();
       overlay.set_fill(true);
-      const color = this.moonTexture === "moon-sky-blue-overlay.png" ? this.skyColor : (this.moonTexture === "moon-dark-gray-overlay.png" ? "#5A5A5A" : "#808080");
+      const color = "#1F1F1F";
       overlay.set_fillColor(color);
       overlay.set_lineColor(color);
       locations.forEach(pt => overlay.addPoint(pt.ra, pt.dec));
@@ -1627,10 +1633,7 @@ export default defineComponent({
 
     updateWWTLocation() {
       this.wwtSettings.set_locationLat(R2D * this.location.latitudeRad);
-      this.wwtSettings.set_locationLng(R2D * this.location.longitudeRad );
-      if(this.showHorizon) {
-        this.updateFrontAnnotations();
-      }
+      this.wwtSettings.set_locationLng(R2D * this.location.longitudeRad);
     },
 
     updateLocation(location: string) {

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -1118,16 +1118,12 @@ export default defineComponent({
   },
 
   mounted() {
-    console.log(Annotation2);
     this.waitForReady().then(async () => {
 
       this.backgroundImagesets = [...skyBackgroundImagesets];
 
       console.log("initial camera params RA, Dec:", R2D * this.initialCameraParams.raRad/15, R2D * this.initialCameraParams.decRad);
 
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      window.app = this;
       console.log(this);
       this.setTime(this.dateTime);
 
@@ -1441,8 +1437,6 @@ export default defineComponent({
         let y1: number;
         let x2: number;
         let y2: number;
-        let xc: number;
-        let yc: number;
 
         if (sunPoint.x === 0) {
 
@@ -1457,15 +1451,12 @@ export default defineComponent({
           y1 = ysh;
           x2 = -x1;
           y2 = ysh;
-          xc = 0;
-          yc = ysh;
 
         } else {
 
           // m is the slope of the line joining the moon and the sun
-          // mPerp is the slope of a perpendicular line
-          // yInt is the y-intercept of the perpendicular bisector between Sun and Moon points
-          const m = sunPoint.y / sunPoint.x;
+          // mPerp is the slope of a line perpendicular to the line joining the moon and the sun
+          // yInt is the y-intercept of a line passing through the two points of intersection
           const mPerp = -sunPoint.x / sunPoint.y;
           const yInt = (sunPoint.x * sunPoint.x + sunPoint.y * sunPoint.y - (rSunPx * rSunPx - rMoonPx * rMoonPx)) / (2 * sunPoint.y);
 
@@ -1482,14 +1473,6 @@ export default defineComponent({
           x2 = (-b - sqrDisc) / (2 * a);
           y1 = mPerp * x1 + yInt;
           y2 = mPerp * x2 + yInt;
-
-          // Find the point at the edge of the moon along the line joining their centers
-          xc = rMoonPx / Math.sqrt(1 + m * m);
-          if (sunPoint.x < 0) {
-            xc *= -1;
-          }
-          yc = m * xc;
-          yc;
         }
 
         // The standard-position angle of the sun-moon line in the moon's reference frame

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -880,7 +880,7 @@ export default defineComponent({
     sunPlace.set_names(["Sun"]);
     sunPlace.set_classification(Classification.solarSystem);   
     sunPlace.set_target(SolarSystemObjects.sun);
-    sunPlace.set_zoomLevel(5.2);
+    sunPlace.set_zoomLevel(20);
 
     const moonPlace = new Place();
     moonPlace.set_names(["Moon"]);

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -2142,6 +2142,18 @@ export default defineComponent({
       this.updateMoonTexture();
     },
 
+    wwtRollRad(angle: number) {
+      if (angle !== 0) {
+        this.gotoRADecZoom({
+          raRad: this.wwtRARad,
+          decRad: this.wwtDecRad,
+          zoomDeg: this.wwtZoomDeg,
+          rollRad: 0,
+          instant: true
+        });
+      }
+    },
+
     useRegularMoon(_show: boolean) {
       this.updateMoonTexture();
     },

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -1386,7 +1386,6 @@ export default defineComponent({
 
     // This assumes that the input angles are in the range [0, 2pi)
     angleBetween(test: number, lower: number, upper: number): boolean {
-      console.log(test, lower, upper);
       if (lower < upper) {
         return test >= lower && test <= upper;
       } else {
@@ -1394,7 +1393,7 @@ export default defineComponent({
       }
     },
 
-    updateMoonOverlay() {
+    createMoonOverlay() {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       const canvasHeight: number = this.wwtControl.canvas.height;
@@ -1422,6 +1421,12 @@ export default defineComponent({
 
       const points: { x: number; y: number }[] = [];
       const sunMoonDistance = Math.sqrt(sunPoint.x * sunPoint.x + sunPoint.y * sunPoint.y);
+
+      // If there's no sun/moon intersection, no need to continue
+      if (sunMoonDistance > rMoonPx + rSunPx) {
+        return;
+      }
+
       const n = 25;
       
       // If the moon is completely "inside" of the sun
@@ -1934,7 +1939,7 @@ export default defineComponent({
             this.createSky(when);
           }
         }
-        this.updateMoonOverlay();
+        this.createMoonOverlay();
       }
     },
 

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -2199,10 +2199,10 @@ export default defineComponent({
       this.playing = false;
       this.updateWWTLocation();
 
-      // We need to let the location update before we redraw the horizon
-      this.$nextTick(() => {
-        this.updateFrontAnnotations();
-      });
+      // We need to let the location update before we redraw the horizon and overlay
+      // Not a huge fan of having to do this, but we really need a frame render to update e.g. sun/moon positions
+      this.wwtControl.renderOneFrame();
+      this.updateFrontAnnotations();
 
       this.centerSun();
     },

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -1429,7 +1429,7 @@ export default defineComponent({
         return;
       }
 
-      const n = 25;
+      const n = 50;
       
       // If the moon is completely "inside" of the sun
       if (sunMoonDistance < rSunPx - rMoonPx) {
@@ -2147,6 +2147,7 @@ export default defineComponent({
 
     useRegularMoon(_show: boolean) {
       this.updateMoonTexture();
+      this.updateFrontAnnotations(this.dateTime);
     },
 
     dateTime(_date: Date) {
@@ -2162,9 +2163,9 @@ export default defineComponent({
         if (this.playing) {
           this.playing = false;
           this.selectedTime = this.minTime;
-          setTimeout(() => {
-            this.playing = true;
-          }, 1000);
+          // setTimeout(() => {
+          //   this.playing = true;
+          // }, 1000);
         }
         
         return;

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -1395,11 +1395,6 @@ export default defineComponent({
     },
 
     updateMoonOverlay() {
-      console.log("Creating moon overlay");
-      console.log(Planets);
-      console.log(Planets['_planetLocations']);
-      // const initZoom = this.wwtZoomDeg;
-
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       const canvasHeight: number = this.wwtControl.canvas.height;
@@ -1408,8 +1403,6 @@ export default defineComponent({
       const moonPosition = Planets['_planetLocations'][9];
       const sunPoint = this.findScreenPointForRADec({ ra: sunPosition.RA * 15, dec: sunPosition.dec });
       const moonPoint = this.findScreenPointForRADec({ ra: moonPosition.RA * 15, dec: moonPosition.dec });
-      console.log(sunPoint);
-      console.log(moonPoint);
       moonPoint.y = canvasHeight - moonPoint.y;
       sunPoint.x -= moonPoint.x;
       sunPoint.y = canvasHeight - sunPoint.y - moonPoint.y;
@@ -1420,25 +1413,18 @@ export default defineComponent({
 
       const rMoon = 1740;  // radius of the moon in km
       const rSun = 696_340;
-      console.log(distanceToMoon);
-      console.log(rMoon);
       const thetaMoon = Math.atan2(rMoon, distanceToMoon);
       const thetaSun = Math.atan2(rSun, distanceToSun);
-      console.log(thetaMoon);
-      console.log(this.wwtZoomDeg * D2R);
-      console.log(canvasHeight);
 
       // The factor of 6 comes from the relation between wwtZoomDeg and the actual size of the FOV in degrees
       const rMoonPx = 6 * thetaMoon * canvasHeight / (this.wwtZoomDeg * D2R);
       const rSunPx = 6 * thetaSun * canvasHeight / (this.wwtZoomDeg * D2R);
-      console.log(`ratio: ${rSunPx / rMoonPx}`);
 
       const points: { x: number; y: number }[] = [];
       const sunMoonDistance = Math.sqrt(sunPoint.x * sunPoint.x + sunPoint.y * sunPoint.y);
       const n = 25;
       
       // If the moon is completely "inside" of the sun
-      console.log(sunMoonDistance, rSunPx - rMoonPx);
       if (sunMoonDistance < rSunPx - rMoonPx) {
         for (let i = 0; i <= n; i++) {
           const angle = (i / n) * 2 * Math.PI;
@@ -1461,8 +1447,6 @@ export default defineComponent({
           }
           x1 = Math.sqrt(rMoonPx * rMoonPx - ysh * ysh);
           if (isNaN(x1)) {
-            console.log("x1 isNan");
-            console.log(rMoonPx, ysh);
             return;
           }
           y1 = ysh;
@@ -1487,8 +1471,6 @@ export default defineComponent({
 
           const sqrDisc = Math.sqrt(b * b - 4 * a * c);
           if (isNaN(sqrDisc)) {
-            console.log("sqrDisc isNan");
-            console.log(a, b, c);
             return;
           }
           x1 = (-b + sqrDisc) / (2 * a);
@@ -1507,13 +1489,11 @@ export default defineComponent({
 
         // The standard-position angle of the sun-moon line in the moon's reference frame
         const alpha = this.angleInZeroToTwoPi(Math.atan2(sunPoint.y, sunPoint.x));
-        console.log(sunPoint);
 
         let theta1 = Math.atan2(y1 / rMoonPx, x1 / rMoonPx);
         let theta2 = Math.atan2(y2 / rMoonPx, x2 / rMoonPx);
         theta1 = this.angleInZeroToTwoPi(theta1);
         theta2 = this.angleInZeroToTwoPi(theta2);
-        console.log(alpha, theta1, theta2, this.angleBetween(alpha, theta1, theta2));
         if (!this.angleBetween(alpha, theta1, theta2)) {
           const t = theta1;
           theta1 = theta2;
@@ -1527,13 +1507,9 @@ export default defineComponent({
         const rangeSize = theta2 - theta1;
         for (let i = 0; i <= n; i++) {
           const angle = theta1 + (i / n) * rangeSize;
-          // console.log(`angle: ${angle}`);
           points.push({ x: rMoonPx * Math.cos(angle), y: rMoonPx * Math.sin(angle) });
         }
 
-        console.log(`alpha: ${alpha}`);
-        console.log(`theta1: ${theta1}`);
-        console.log(`theta2: ${theta2}`);
 
         // We now need to somewhat repeat this analysis in the Sun frame
 
@@ -1542,16 +1518,11 @@ export default defineComponent({
         thetaS1 = this.angleInZeroToTwoPi(thetaS1);
         thetaS2 = this.angleInZeroToTwoPi(thetaS2);
         const alphaS = this.angleInZeroToTwoPi(Math.PI + alpha);
-        console.log(alphaS, thetaS1, thetaS2, this.angleBetween(alphaS, thetaS1, thetaS2));
         if (!this.angleBetween(alphaS, thetaS1, thetaS2)) {
           const t = thetaS1;
           thetaS1 = thetaS2;
           thetaS2 = t;
         }
-
-        console.log(`alphaS: ${alphaS}`);
-        console.log(`thetaS1: ${thetaS1}`);
-        console.log(`thetaS2: ${thetaS2}`);
 
         if (thetaS1 > thetaS2) {
           thetaS1 -= 2 * Math.PI;
@@ -1559,7 +1530,6 @@ export default defineComponent({
         const rangeSizeS = thetaS2 - thetaS1;
         for (let i = 0; i <= n; i++) {
           const angle = thetaS1 + (i / n) * rangeSizeS;
-          // console.log(`angleS: ${angle}`);
           points.push({ x: rSunPx * Math.cos(angle) + sunPoint.x, y: rSunPx * Math.sin(angle) + sunPoint.y });
         }
       }
@@ -1576,10 +1546,7 @@ export default defineComponent({
       // The fact that we're going to re-flip the y axis makes the sign here opposite from what one would expect
       points.sort((p1, p2) => - Math.atan2(p2.y - centroidY, p2.x - centroidX) + Math.atan2(p1.y - centroidY, p1.x - centroidX));
 
-      console.log(points);
-
       const locations = points.map(pt => this.findRADecForScreenPoint({ x: pt.x, y: canvasHeight - pt.y }));
-      console.log(locations);
       const overlay = new Poly2();
       overlay.set_fill(true);
       const color = this.moonTexture === "moon-sky-blue-overlay.png" ? this.skyColor : (this.moonTexture === "moon-dark-gray-overlay.png" ? "#5A5A5A" : "#808080");
@@ -1587,8 +1554,6 @@ export default defineComponent({
       overlay.set_lineColor(color);
       locations.forEach(pt => overlay.addPoint(pt.ra, pt.dec));
       Annotation2.addAnnotation(overlay);
-      console.log(overlay);
-
     },
 
 

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -770,7 +770,7 @@ import { defineComponent, PropType } from "vue";
 import { MiniDSBase, BackgroundImageset, skyBackgroundImagesets } from "@minids/common";
 import { GotoRADecZoomParams } from "@wwtelescope/engine-pinia";
 import { Classification, SolarSystemObjects } from "@wwtelescope/engine-types";
-import { Folder, Grids, LayerManager, Planets, Poly, Settings, WWTControl, Place, Texture } from "@wwtelescope/engine";
+import { Folder, Grids, LayerManager, Planets, Poly, Settings, WWTControl, Place, Texture, CAAMoon } from "@wwtelescope/engine";
 import { Annotation2, Poly2 } from "./Annotation2";
 
 import { getTimezoneOffset, formatInTimeZone } from "date-fns-tz";
@@ -880,7 +880,7 @@ export default defineComponent({
     sunPlace.set_names(["Sun"]);
     sunPlace.set_classification(Classification.solarSystem);   
     sunPlace.set_target(SolarSystemObjects.sun);
-    sunPlace.set_zoomLevel(20);
+    sunPlace.set_zoomLevel(5.2);
 
     const moonPlace = new Place();
     moonPlace.set_names(["Moon"]);
@@ -1118,12 +1118,16 @@ export default defineComponent({
   },
 
   mounted() {
+    console.log(Annotation2);
     this.waitForReady().then(async () => {
 
       this.backgroundImagesets = [...skyBackgroundImagesets];
 
       console.log("initial camera params RA, Dec:", R2D * this.initialCameraParams.raRad/15, R2D * this.initialCameraParams.decRad);
 
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      window.app = this;
       console.log(this);
       this.setTime(this.dateTime);
 
@@ -1195,6 +1199,7 @@ export default defineComponent({
       window.addEventListener('resize', this.onResize);
       this.onResize();
     });
+
   },
 
   computed: {
@@ -1374,6 +1379,218 @@ export default defineComponent({
       });
     },
 
+    angleInZeroToTwoPi(angle: number): number {
+      const twoPi = 2 * Math.PI;
+      return ((angle% twoPi) + twoPi) % twoPi;
+    },
+
+    // This assumes that the input angles are in the range [0, 2pi)
+    angleBetween(test: number, lower: number, upper: number): boolean {
+      console.log(test, lower, upper);
+      if (lower < upper) {
+        return test >= lower && test <= upper;
+      } else {
+        return test >= lower || test <= upper;
+      }
+    },
+
+    updateMoonOverlay() {
+      console.log("Creating moon overlay");
+      console.log(Planets);
+      console.log(Planets['_planetLocations']);
+      // const initZoom = this.wwtZoomDeg;
+
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      const canvasHeight: number = this.wwtControl.canvas.height;
+
+      const sunPosition = Planets['_planetLocations'][0];
+      const moonPosition = Planets['_planetLocations'][9];
+      const sunPoint = this.findScreenPointForRADec({ ra: sunPosition.RA * 15, dec: sunPosition.dec });
+      const moonPoint = this.findScreenPointForRADec({ ra: moonPosition.RA * 15, dec: moonPosition.dec });
+      console.log(sunPoint);
+      console.log(moonPoint);
+      moonPoint.y = canvasHeight - moonPoint.y;
+      sunPoint.x -= moonPoint.x;
+      sunPoint.y = canvasHeight - sunPoint.y - moonPoint.y;
+
+      const jd = this.getJulian(this.selectedDate);
+      const distanceToMoon = CAAMoon.radiusVector(jd);
+      const distanceToSun = 149_597_871;
+
+      const rMoon = 1740;  // radius of the moon in km
+      const rSun = 696_340;
+      console.log(distanceToMoon);
+      console.log(rMoon);
+      const thetaMoon = Math.atan2(rMoon, distanceToMoon);
+      const thetaSun = Math.atan2(rSun, distanceToSun);
+      console.log(thetaMoon);
+      console.log(this.wwtZoomDeg * D2R);
+      console.log(canvasHeight);
+
+      // The factor of 6 comes from the relation between wwtZoomDeg and the actual size of the FOV in degrees
+      const rMoonPx = 6 * thetaMoon * canvasHeight / (this.wwtZoomDeg * D2R);
+      const rSunPx = 6 * thetaSun * canvasHeight / (this.wwtZoomDeg * D2R);
+      console.log(`ratio: ${rSunPx / rMoonPx}`);
+
+      const points: { x: number; y: number }[] = [];
+      const sunMoonDistance = Math.sqrt(sunPoint.x * sunPoint.x + sunPoint.y * sunPoint.y);
+      const n = 25;
+      
+      // If the moon is completely "inside" of the sun
+      console.log(sunMoonDistance, rSunPx - rMoonPx);
+      if (sunMoonDistance < rSunPx - rMoonPx) {
+        for (let i = 0; i <= n; i++) {
+          const angle = (i / n) * 2 * Math.PI;
+          points.push({ x: rMoonPx * Math.cos(angle), y: rMoonPx * Math.sin(angle) });
+        }
+      } else {
+
+        let x1: number;
+        let y1: number;
+        let x2: number;
+        let y2: number;
+        let xc: number;
+        let yc: number;
+
+        if (sunPoint.x === 0) {
+
+          const ysh = 0.5 * sunPoint.y;
+          if (ysh >= rMoonPx) {
+            return;
+          }
+          x1 = Math.sqrt(rMoonPx * rMoonPx - ysh * ysh);
+          if (isNaN(x1)) {
+            console.log("x1 isNan");
+            console.log(rMoonPx, ysh);
+            return;
+          }
+          y1 = ysh;
+          x2 = -x1;
+          y2 = ysh;
+          xc = 0;
+          yc = ysh;
+
+        } else {
+
+          // m is the slope of the line joining the moon and the sun
+          // mPerp is the slope of a perpendicular line
+          // yInt is the y-intercept of the perpendicular bisector between Sun and Moon points
+          const m = sunPoint.y / sunPoint.x;
+          const mPerp = -sunPoint.x / sunPoint.y;
+          const yInt = (sunPoint.x * sunPoint.x + sunPoint.y * sunPoint.y - (rSunPx * rSunPx - rMoonPx * rMoonPx)) / (2 * sunPoint.y);
+
+          // Find the x-coordinates of the edge points of the moon-sun intersection
+          const a = (1 + mPerp * mPerp);
+          const b = 2 * mPerp * yInt;
+          const c = yInt * yInt - rMoonPx * rMoonPx;
+
+          const sqrDisc = Math.sqrt(b * b - 4 * a * c);
+          if (isNaN(sqrDisc)) {
+            console.log("sqrDisc isNan");
+            console.log(a, b, c);
+            return;
+          }
+          x1 = (-b + sqrDisc) / (2 * a);
+          x2 = (-b - sqrDisc) / (2 * a);
+          y1 = mPerp * x1 + yInt;
+          y2 = mPerp * x2 + yInt;
+
+          // Find the point at the edge of the moon along the line joining their centers
+          xc = rMoonPx / Math.sqrt(1 + m * m);
+          if (sunPoint.x < 0) {
+            xc *= -1;
+          }
+          yc = m * xc;
+          yc;
+        }
+
+        // The standard-position angle of the sun-moon line in the moon's reference frame
+        const alpha = this.angleInZeroToTwoPi(Math.atan2(sunPoint.y, sunPoint.x));
+        console.log(sunPoint);
+
+        let theta1 = Math.atan2(y1 / rMoonPx, x1 / rMoonPx);
+        let theta2 = Math.atan2(y2 / rMoonPx, x2 / rMoonPx);
+        theta1 = this.angleInZeroToTwoPi(theta1);
+        theta2 = this.angleInZeroToTwoPi(theta2);
+        console.log(alpha, theta1, theta2, this.angleBetween(alpha, theta1, theta2));
+        if (!this.angleBetween(alpha, theta1, theta2)) {
+          const t = theta1;
+          theta1 = theta2;
+          theta2 = t;
+        }
+
+        if (theta1 > theta2) {
+          theta1 -= 2 * Math.PI;
+        }
+
+        const rangeSize = theta2 - theta1;
+        for (let i = 0; i <= n; i++) {
+          const angle = theta1 + (i / n) * rangeSize;
+          // console.log(`angle: ${angle}`);
+          points.push({ x: rMoonPx * Math.cos(angle), y: rMoonPx * Math.sin(angle) });
+        }
+
+        console.log(`alpha: ${alpha}`);
+        console.log(`theta1: ${theta1}`);
+        console.log(`theta2: ${theta2}`);
+
+        // We now need to somewhat repeat this analysis in the Sun frame
+
+        let thetaS1 = Math.atan2((y1 - sunPoint.y) / rSunPx, (x1 - sunPoint.x) / rSunPx);
+        let thetaS2 = Math.atan2((y2 - sunPoint.y) / rSunPx, (x2 - sunPoint.x) / rSunPx);
+        thetaS1 = this.angleInZeroToTwoPi(thetaS1);
+        thetaS2 = this.angleInZeroToTwoPi(thetaS2);
+        const alphaS = this.angleInZeroToTwoPi(Math.PI + alpha);
+        console.log(alphaS, thetaS1, thetaS2, this.angleBetween(alphaS, thetaS1, thetaS2));
+        if (!this.angleBetween(alphaS, thetaS1, thetaS2)) {
+          const t = thetaS1;
+          thetaS1 = thetaS2;
+          thetaS2 = t;
+        }
+
+        console.log(`alphaS: ${alphaS}`);
+        console.log(`thetaS1: ${thetaS1}`);
+        console.log(`thetaS2: ${thetaS2}`);
+
+        if (thetaS1 > thetaS2) {
+          thetaS1 -= 2 * Math.PI;
+        }
+        const rangeSizeS = thetaS2 - thetaS1;
+        for (let i = 0; i <= n; i++) {
+          const angle = thetaS1 + (i / n) * rangeSizeS;
+          // console.log(`angleS: ${angle}`);
+          points.push({ x: rSunPx * Math.cos(angle) + sunPoint.x, y: rSunPx * Math.sin(angle) + sunPoint.y });
+        }
+      }
+
+      // We made a translation into the moon's frame, so undo that
+      for (let i = 0; i < points.length; i++) {
+        points[i].x += moonPoint.x;
+        points[i].y += moonPoint.y;
+      }
+
+      const centroidX = points.reduce((s, p) => s + p.x, 0) / points.length;
+      const centroidY = points.reduce((s, p) => s + p.y, 0) / points.length;
+
+      // The fact that we're going to re-flip the y axis makes the sign here opposite from what one would expect
+      points.sort((p1, p2) => - Math.atan2(p2.y - centroidY, p2.x - centroidX) + Math.atan2(p1.y - centroidY, p1.x - centroidX));
+
+      console.log(points);
+
+      const locations = points.map(pt => this.findRADecForScreenPoint({ x: pt.x, y: canvasHeight - pt.y }));
+      console.log(locations);
+      const overlay = new Poly2();
+      overlay.set_fill(true);
+      const color = this.moonTexture === "moon-sky-blue-overlay.png" ? this.skyColor : (this.moonTexture === "moon-dark-gray-overlay.png" ? "#5A5A5A" : "#808080");
+      overlay.set_fillColor(color);
+      overlay.set_lineColor(color);
+      locations.forEach(pt => overlay.addPoint(pt.ra, pt.dec));
+      Annotation2.addAnnotation(overlay);
+      console.log(overlay);
+
+    },
+
 
     onWWTRenderFrame(wwtControl: WWTControl) {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -1459,7 +1676,7 @@ export default defineComponent({
       this.wwtSettings.set_locationLat(R2D * this.location.latitudeRad);
       this.wwtSettings.set_locationLng(R2D * this.location.longitudeRad );
       if(this.showHorizon) {
-        this.updateHorizon();
+        this.updateFrontAnnotations();
       }
     },
 
@@ -1507,7 +1724,7 @@ export default defineComponent({
 
     onTimeSliderChange() {
       this.$nextTick(() => {
-        this.updateHorizon(this.dateTime);
+        this.updateFrontAnnotations(this.dateTime);
       });
     },
 
@@ -1738,10 +1955,10 @@ export default defineComponent({
       if (this.syncDateTimeWithWWTCurrentTime) {
         this.setTime(this.dateTime);
       }
-      this.updateHorizon(this.dateTime); 
+      this.updateFrontAnnotations(this.dateTime);
     },
 
-    updateHorizon(when: Date | null = null) {
+    updateFrontAnnotations(when: Date | null = null) {
       try {
         this.removeAnnotations();
       }
@@ -1752,6 +1969,7 @@ export default defineComponent({
             this.createSky(when);
           }
         }
+        this.updateMoonOverlay();
       }
     },
 
@@ -1803,7 +2021,7 @@ export default defineComponent({
       this.showAltAzGrid = false;
       this.skyColor = this.skyColorNight;
       this.horizonOpacity = 0.6;
-      this.updateHorizon(); // manually update horizon
+      this.updateFrontAnnotations(); // manually update horizon
       this.playbackRate = this.scopeRate;
       // this.setForegroundImageByName("Black Sky Background");
       // this.setForegroundOpacity(100);
@@ -1950,12 +2168,12 @@ export default defineComponent({
     },
 
     showHorizon(_show: boolean) {
-      this.updateHorizon();
+      this.updateFrontAnnotations();
       this.updateMoonTexture();
     },
 
     showSky(_show: boolean) {
-      this.updateHorizon();
+      this.updateFrontAnnotations();
       this.updateMoonTexture();
     },
 
@@ -1985,7 +2203,7 @@ export default defineComponent({
       }
       
       this.selectedTime = time.getTime();
-      this.updateHorizon(time);
+      this.updateFrontAnnotations(time);
     },
 
     selectedTimezone(newTz: string, oldTz: string) {
@@ -2015,7 +2233,7 @@ export default defineComponent({
 
       // We need to let the location update before we redraw the horizon
       this.$nextTick(() => {
-        this.updateHorizon();
+        this.updateFrontAnnotations();
       });
 
       this.centerSun();
@@ -2056,7 +2274,7 @@ export default defineComponent({
     },
 
     skyColor(_color: string) {
-      this.updateHorizon();
+      this.updateFrontAnnotations();
     },
 
     sunAboveHorizon(isAbove: boolean) {

--- a/annular-eclipse-2023/src/shims-wwt.d.ts
+++ b/annular-eclipse-2023/src/shims-wwt.d.ts
@@ -41,5 +41,13 @@ declare module "@wwtelescope/engine" {
 
   export class Planets {
     static _planetTextures: Texture[];
+
+    // Technically this is a list of AstroRaDec objects, but this is a good enough definition
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    static _planetLocations: { RA: number; dec: number }[];
+  }
+
+  export class CAAMoon {
+    static radiusVector(JD: number): number;
   }
 }


### PR DESCRIPTION
This PR adds the overlay that covers the area where the sun and moon intersect on the sky. This is implemented as an annotation that gets redrawn whenever the time or viewer mode change.

The basic idea behind the implementation of the annotation is:
- Convert our points to a reasonable Cartesian space (screen space, but with y going up rather than down, and centered on the moon)
- Do the circular geometry there. This involves finding the points of intersection and choosing the correct arcs between them on the sun and moon.
- Convert back to world space

There's some extra handling for the case when the moon's footprint is entirely inside that of the sun's. Also, there seems to be a bug in at least part of the world <---> screen conversion in WWT when the roll angle is nonzero, so this PR additionally pins the camera's roll angle to zero.

Here's a quick video of what this looks like. The color is set [here](https://github.com/Carifio24/minids/blob/lune-r-eclipse/annular-eclipse-2023/src/AnnularEclipse2023.vue#L1521), and I don't think the current gray choices look particularly great, so feel free to change.


https://github.com/cosmicds/minids/assets/14281631/3a0f0d41-cb23-4e4f-a045-3ec00edebaf0