### PR TITLE
Wire up eclipse mini to backend

### DIFF
--- a/annular-eclipse-2023/package.json
+++ b/annular-eclipse-2023/package.json
@@ -7,6 +7,7 @@
     "@fortawesome/vue-fontawesome": "^3.0.3",
     "@kyvg/vue3-notification": "^3.0.2",
     "@minids/common": "workspace:0.0.0",
+    "uuid": "^9.0.1",
     "vue": "^3.3.4",
     "vuetify": "^3.3.14",
     "webpack-plugin-vuetify": "^2.0.1"
@@ -18,6 +19,7 @@
     "serve": "./patch.sh; vue-cli-service serve"
   },
   "devDependencies": {
+    "@types/uuid": "^9.0.4",
     "@typescript-eslint/eslint-plugin": "^6.5.0",
     "@typescript-eslint/parser": "^6.5.0",
     "@typescript-eslint/typescript-estree": "7.0.0-alpha.0",

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -1016,6 +1016,7 @@ import { Annotation2, Poly2 } from "./Annotation2";
 
 import { getTimezoneOffset, formatInTimeZone } from "date-fns-tz";
 import tzlookup from "tz-lookup";
+import { v4 } from "uuid";
 
 import { drawSkyOverlays, makeAltAzGridText, layerManagerDraw, updateViewParameters, renderOneFrame } from "./wwt-hacks";
 
@@ -1140,7 +1141,11 @@ export default defineComponent({
     const presetLocationsVisited = queryData ? [] : [selectedLocation];
     const userSelectedLocationsVisited = queryData ? [[queryData.latitudeDeg, queryData.longitudeDeg]] : [];
 
+    const uuid = v4();
+
     return {
+      uuid,
+
       showSplashScreen: false, // FIX later
       backgroundImagesets: [] as BackgroundImageset[],
       sheet: null as SheetType,

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -1013,6 +1013,7 @@ import { GotoRADecZoomParams } from "@wwtelescope/engine-pinia";
 import { Classification, SolarSystemObjects } from "@wwtelescope/engine-types";
 import { Folder, Grids, LayerManager, Planets, Poly, Settings, WWTControl, Place, Texture, CAAMoon } from "@wwtelescope/engine";
 import { Annotation2, Poly2 } from "./Annotation2";
+import { MCSelectionStatus } from "./MCRadiogroup.vue";
 
 import { getTimezoneOffset, formatInTimeZone } from "date-fns-tz";
 import tzlookup from "tz-lookup";
@@ -1980,14 +1981,15 @@ export default defineComponent({
       });
     },
 
-    onAnswerSelected(event: unknown) { // Update with a real type
+    onAnswerSelected(event: MCSelectionStatus) { // Update with a real type
       if (this.responseOptOut) {
         return;
       }
       fetch(`${MINIDS_BASE_URL}/annular-eclipse-2023/response`, {
         method: "POST",
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          response: event.response,
+          response: event.text,
           // eslint-disable-next-line @typescript-eslint/naming-convention
           user_uuid: this.uuid, preset_locations: toRaw(this.presetLocationsVisited), user_selected_locations: toRaw(this.userSelectedLocationsVisited)
         })

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -1164,7 +1164,7 @@ export default defineComponent({
     return {
       uuid,
       responseOptOut,
-      currentAnswer: null as string | null,
+      mcResponses: [] as string[],
 
       showSplashScreen: true,
       backgroundImagesets: [] as BackgroundImageset[],
@@ -2004,15 +2004,17 @@ export default defineComponent({
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          response: this.currentAnswer,
           // eslint-disable-next-line @typescript-eslint/naming-convention
-          user_uuid: this.uuid, preset_locations: toRaw(this.presetLocationsVisited), user_selected_locations: toRaw(this.userSelectedLocationsVisited)
+          user_uuid: this.uuid, mc_responses: this.mcResponses,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          preset_locations: toRaw(this.presetLocationsVisited), user_selected_locations: toRaw(this.userSelectedLocationsVisited)
         })
       });
     },
 
     onAnswerSelected(event: MCSelectionStatus) {
-      this.currentAnswer = event.text;
+      this.mcResponses.push(event.text);
+      this.sendDataToDatabase();
     },
 
     logLocation() {
@@ -2557,10 +2559,6 @@ export default defineComponent({
       console.log("selected location", locname);
     },
 
-    currentAnswer(_answer: string) {
-      this.sendDataToDatabase();
-    },
-    
     playing(play: boolean) {
       console.log(`${play ? 'Playing:' : 'Stopping:'} at ${this.playbackRate}x real time`);
       this.setClockSync(play);

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -1087,6 +1087,8 @@ type HorizontalRad = {
 
 let queryData: LocationDeg | null = null;
 const USER_SELECTED = "User Selected" as const;
+const UUID_KEY = "eclipse-mini-uuid" as const;
+const OPT_OUT_KEY = "eclipse-mini-optout" as const;
 
 export default defineComponent({
   extends: MiniDSBase,
@@ -1141,10 +1143,14 @@ export default defineComponent({
     const presetLocationsVisited = queryData ? [] : [selectedLocation];
     const userSelectedLocationsVisited = queryData ? [[queryData.latitudeDeg, queryData.longitudeDeg]] : [];
 
-    const uuid = v4();
+    const uuid = window.localStorage.getItem(UUID_KEY) ?? v4();
+    window.localStorage.setItem(UUID_KEY, uuid);
+
+    const responseOptOut = window.localStorage.getItem(OPT_OUT_KEY) === "true" ?? false;
 
     return {
       uuid,
+      responseOptOut,
 
       showSplashScreen: false, // FIX later
       backgroundImagesets: [] as BackgroundImageset[],
@@ -2403,6 +2409,10 @@ export default defineComponent({
   },
 
   watch: {
+    responseOptOut(optOut: boolean) {
+      window.localStorage.setItem(OPT_OUT_KEY, String(optOut));
+    },
+
     showAltAzGrid(show: boolean) {
       this.wwtSettings.set_showAltAzGrid(show);
       this.wwtSettings.set_showAltAzGridText(show);

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -1981,6 +1981,9 @@ export default defineComponent({
     },
 
     onAnswerSelected(event: unknown) { // Update with a real type
+      if (this.responseOptOut) {
+        return;
+      }
       fetch(`${MINIDS_BASE_URL}/annular-eclipse-2023/response`, {
         method: "POST",
         body: JSON.stringify({

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -1164,6 +1164,7 @@ export default defineComponent({
     return {
       uuid,
       responseOptOut,
+      currentAnswer: null as string | null,
 
       showSplashScreen: true,
       backgroundImagesets: [] as BackgroundImageset[],
@@ -1995,19 +1996,23 @@ export default defineComponent({
       });
     },
 
-    onAnswerSelected(event: MCSelectionStatus) { // Update with a real type
+    sendDataToDatabase() {
       if (this.responseOptOut) {
         return;
       }
       fetch(`${MINIDS_BASE_URL}/annular-eclipse-2023/response`, {
-        method: "POST",
+        method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          response: event.text,
+          response: this.currentAnswer,
           // eslint-disable-next-line @typescript-eslint/naming-convention
           user_uuid: this.uuid, preset_locations: toRaw(this.presetLocationsVisited), user_selected_locations: toRaw(this.userSelectedLocationsVisited)
         })
       });
+    },
+
+    onAnswerSelected(event: MCSelectionStatus) {
+      this.currentAnswer = event.text;
     },
 
     logLocation() {
@@ -2536,6 +2541,7 @@ export default defineComponent({
     locationDeg(loc: LocationDeg) {
       if (this.selectedLocation === USER_SELECTED) {
         this.userSelectedLocationsVisited.push([loc.latitudeDeg, loc.longitudeDeg]);
+        this.sendDataToDatabase();
       }
     },
 
@@ -2546,8 +2552,13 @@ export default defineComponent({
       }
       if (locname !== USER_SELECTED) {
         this.presetLocationsVisited.push(locname);
+        this.sendDataToDatabase();
       }
       console.log("selected location", locname);
+    },
+
+    currentAnswer(_answer: string) {
+      this.sendDataToDatabase();
     },
     
     playing(play: boolean) {

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -65,7 +65,7 @@
                 :radio-options="['A', 'B','C']"
                 :feedbacks="['Not that one.<br/>Try again!', 'Not that one.<br/>Try again!', 'Yes! It passes from Oregon to Texas']"
                 :correct-answers="[2]"
-                @select="(e: any) => { console.log(e);}"
+                @select="onAnswerSelected"
                 colorWrong="#4a2323"
                 colorRight="green"
                 > 
@@ -1007,8 +1007,8 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType } from "vue";
-import { MiniDSBase, BackgroundImageset, skyBackgroundImagesets } from "@minids/common";
+import { defineComponent, toRaw, PropType } from "vue";
+import { MiniDSBase, BackgroundImageset, skyBackgroundImagesets, MINIDS_BASE_URL } from "@minids/common";
 import { GotoRADecZoomParams } from "@wwtelescope/engine-pinia";
 import { Classification, SolarSystemObjects } from "@wwtelescope/engine-types";
 import { Folder, Grids, LayerManager, Planets, Poly, Settings, WWTControl, Place, Texture, CAAMoon } from "@wwtelescope/engine";
@@ -1977,6 +1977,17 @@ export default defineComponent({
     onTimeSliderChange() {
       this.$nextTick(() => {
         this.updateFrontAnnotations(this.dateTime);
+      });
+    },
+
+    onAnswerSelected(event: unknown) { // Update with a real type
+      fetch(`${MINIDS_BASE_URL}/annular-eclipse-2023/response`, {
+        method: "POST",
+        body: JSON.stringify({
+          response: event.response,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          user_uuid: this.uuid, preset_locations: toRaw(this.presetLocationsVisited), user_selected_locations: toRaw(this.userSelectedLocationsVisited)
+        })
       });
     },
 

--- a/annular-eclipse-2023/src/MCRadiogroup.vue
+++ b/annular-eclipse-2023/src/MCRadiogroup.vue
@@ -79,14 +79,13 @@ import { VRadio } from 'vuetify/components/VRadio';
 
 // :border="(index==column ? `10px solid ${color(index)}` : '10px solid transparent')"
 
-// create a select type
-type Status = {
+export interface MCSelectionStatus {
   index: number,
   text: string,
   correct: boolean,
   neutral: boolean,
   tries: number
-};
+}
 
 export default defineComponent({
 
@@ -164,17 +163,13 @@ export default defineComponent({
     
   },
   emits: {
-    select(status: Status) {
+    select(status: MCSelectionStatus) {
       return typeof status.index === 'number' &&
             typeof status.text === 'string' &&
             typeof status.correct === 'boolean' &&
             typeof status.neutral === 'boolean' &&
             typeof status.tries === 'number';
     }
-  },
-  
-  created() {
-    
   },
   
   data: function () {

--- a/annular-eclipse-2023/src/main.ts
+++ b/annular-eclipse-2023/src/main.ts
@@ -8,7 +8,7 @@ import GifPlayPause from "./GifPlayPause.vue";
 import MCRadiogroup from "./MCRadiogroup.vue";
 import FlipTransition from "./FlipTransition.vue";
 import ImageLabel from "./ImageLabel.vue";
-import  Credits from "./Credits.vue";
+import Credits from "./Credits.vue";
 
 import "./polyfills";
 

--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -5,6 +5,7 @@ import LocationSelector from "./components/LocationSelector.vue";
 import DefaultMiniCredits from "./components/DefaultMiniCredits.vue";
 import { BackgroundImageset, skyBackgroundImagesets } from "./background";
 import Gallery from "./components/Gallery.vue";
+import { API_BASE_URL, MINIDS_BASE_URL, R2D, D2R } from "./utils";
 
 export {
   BackgroundImageset,
@@ -14,5 +15,9 @@ export {
   IconButton,
   LocationSelector,
   skyBackgroundImagesets,
-  DefaultMiniCredits
+  DefaultMiniCredits,
+  API_BASE_URL,
+  MINIDS_BASE_URL,
+  R2D,
+  D2R
 };

--- a/common/src/utils.ts
+++ b/common/src/utils.ts
@@ -1,2 +1,5 @@
 export const D2R = Math.PI / 180;
 export const R2D = 180 / Math.PI;
+
+export const API_BASE_URL = "https://api.cosmicds.cfa.harvard.edu";
+export const MINIDS_BASE_URL = `${API_BASE_URL}/minids`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -522,6 +522,7 @@ __metadata:
     "@fortawesome/vue-fontawesome": ^3.0.3
     "@kyvg/vue3-notification": ^3.0.2
     "@minids/common": "workspace:0.0.0"
+    "@types/uuid": ^9.0.4
     "@typescript-eslint/eslint-plugin": ^6.5.0
     "@typescript-eslint/parser": ^6.5.0
     "@typescript-eslint/typescript-estree": 7.0.0-alpha.0
@@ -535,6 +536,7 @@ __metadata:
     less: ^4.2.0
     less-loader: ^11.1.3
     typescript: latest
+    uuid: ^9.0.1
     vue: ^3.3.4
     vuetify: ^3.3.14
     webpack: ^5.88.2
@@ -1473,6 +1475,13 @@ __metadata:
   version: 6.1.0
   resolution: "@types/tz-lookup@npm:6.1.0"
   checksum: 22f8e6285bc8c1c5c111767de8052ad4586d813f3b36560eddcbb352003e1330190329525328f4a5eb12381971c7ecc1bbd22079b3f4a84e1b19a1a6c56be2c9
+  languageName: node
+  linkType: hard
+
+"@types/uuid@npm:^9.0.4":
+  version: 9.0.4
+  resolution: "@types/uuid@npm:9.0.4"
+  checksum: 356e2504456eaebbc43a5af5ca6c07d71f5ae5520b5767cb1c62cd0ec55475fc4ee3d16a2874f4a5fce78e40e8583025afd3a7d9ba41f82939de310665f53f0e
   languageName: node
   linkType: hard
 
@@ -10978,6 +10987,15 @@ __metadata:
   bin:
     uuid: ./bin/uuid
   checksum: 58de2feed61c59060b40f8203c0e4ed7fd6f99d42534a499f1741218a1dd0c129f4aa1de797bcf822c8ea5da7e4137aa3673431a96dae729047f7aca7b27866f
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "uuid@npm:9.0.1"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 39931f6da74e307f51c0fb463dc2462807531dc80760a9bff1e35af4316131b4fc3203d16da60ae33f07fdca5b56f3f1dd662da0c99fea9aaeab2004780cc5f4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR resolves #183. This is built on top of #231. The changes here are:

* Add data members that keep track of the preset and user-selected locations that the user has visited. These are updated whenever one of these values changes.
* Use the `uuid` package to generate a UUID for the user. This UUID is stored in the brower's local storage, and if one is present in local storage on a page load, that UUID is used rather than creating a new one.
* Add a data value `responseOptOut`, which is also stored in local storage when updated, which is used to initialize the app value on a page load. Currently there isn't yet any UI to modify this. If `responseOptOut` is true, nothing is sent to the backend.
* When an answer is selected on the multiple choice (and the user hasn't opted out), a request (consisting of the user's UUID, the response character, and their lists of locations) is sent to the backend

This uses local storage (as opposed to cookies) so that we can access the values from JavaScript.