### PR TITLE
Include pathname in share URL

### DIFF
--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -2433,7 +2433,8 @@ export default defineComponent({
     },
   
     copyShareURL() {
-      const url = `${window.location.origin}?lat=${this.locationDeg.latitudeDeg}&lon=${this.locationDeg.longitudeDeg}`;
+      const baseURL = `${window.location.origin}${window.location.pathname}`;
+      const url = `${baseURL}?lat=${this.locationDeg.latitudeDeg}&lon=${this.locationDeg.longitudeDeg}`;
       navigator.clipboard
         .writeText(url)
         .then(() =>


### PR DESCRIPTION
This PR fixes the bug that Mary saw with the sharing URLs. I had forgotten to include the URL pathname and was only using the origin) This works fine for e.g. `http://localhost:8080`, but not so much in general.