### PR TITLE
Use API key for minis

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build
         run: yarn build
         env:
-          CDS_API_KEY: ${{ secrets.CDS_API_KEY }}
+          VUE_APP_CDS_API_KEY: ${{ secrets.CDS_API_KEY }}
 
       - name: Get workspaces
         uses: sergeysova/jq-action@v2

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Build
         run: yarn build
+        env:
+          CDS_API_KEY: ${{ secrets.CDS_API_KEY }}
 
       - name: Get workspaces
         uses: sergeysova/jq-action@v2

--- a/annular-eclipse-2023/package.json
+++ b/annular-eclipse-2023/package.json
@@ -27,6 +27,7 @@
     "@vue/cli-service": "^5.0.8",
     "@vue/compiler-sfc": "^3.3.4",
     "@vue/eslint-config-typescript": "^11.0.3",
+    "dotenv-webpack": "^8.0.1",
     "eslint": "^8.48.0",
     "eslint-plugin-vue": "^9.17.0",
     "less": "^4.2.0",

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -2151,7 +2151,7 @@ export default defineComponent({
         headers: {
           "Content-Type": "application/json",
           // eslint-disable-next-line @typescript-eslint/naming-convention
-          "Authorization": process.env.CDS_API_KEY ?? ""
+          "Authorization": process.env.VUE_APP_CDS_API_KEY ?? ""
         },
         body: JSON.stringify({
           // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -2148,7 +2148,11 @@ export default defineComponent({
       }
       fetch(`${MINIDS_BASE_URL}/annular-eclipse-2023/response`, {
         method: "PUT",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          "Authorization": process.env.CDS_API_KEY ?? ""
+        },
         body: JSON.stringify({
           // eslint-disable-next-line @typescript-eslint/naming-convention
           user_uuid: this.uuid, mc_responses: this.mcResponses,
@@ -2159,7 +2163,7 @@ export default defineComponent({
     },
 
     onAnswerSelected(event: MCSelectionStatus) {
-      if(event.text=="C") {
+      if (event.text === "C") {
         this.showLinkToPath = true;
       }
       this.mcResponses.push(event.text);

--- a/annular-eclipse-2023/vue.config.js
+++ b/annular-eclipse-2023/vue.config.js
@@ -1,4 +1,5 @@
 const { VuetifyPlugin } = require('webpack-plugin-vuetify');
+const DotenvWebpack = require("dotenv-webpack");
 const { defineConfig } = require("@vue/cli-service")
 
 module.exports = defineConfig({
@@ -6,7 +7,11 @@ module.exports = defineConfig({
   
   configureWebpack: {
     plugins: [
-      new VuetifyPlugin()
+      new VuetifyPlugin(),
+      new DotenvWebpack({
+        path: ".env",
+        systemvars: true
+      })
     ]
   },
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -531,6 +531,7 @@ __metadata:
     "@vue/cli-service": ^5.0.8
     "@vue/compiler-sfc": ^3.3.4
     "@vue/eslint-config-typescript": ^11.0.3
+    dotenv-webpack: ^8.0.1
     eslint: ^8.48.0
     eslint-plugin-vue: ^9.17.0
     less: ^4.2.0
@@ -4693,6 +4694,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dotenv-defaults@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "dotenv-defaults@npm:2.0.2"
+  dependencies:
+    dotenv: ^8.2.0
+  checksum: c005960bd048e2189c4799e729c41f362e415e6e0b54313d3f31e853a84b049bf770b25cb21c112c2805bb13a8376edc9de451fb514abf8546392d327c27f6e5
+  languageName: node
+  linkType: hard
+
 "dotenv-expand@npm:^5.1.0":
   version: 5.1.0
   resolution: "dotenv-expand@npm:5.1.0"
@@ -4700,10 +4710,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dotenv-webpack@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "dotenv-webpack@npm:8.0.1"
+  dependencies:
+    dotenv-defaults: ^2.0.2
+  peerDependencies:
+    webpack: ^4 || ^5
+  checksum: ee73eda78df90bcf7446763dfe5e518a2054ed6222783856912d2c6a255fdfc041854e125e036ff2603b06fb44f5234713fad5feecb1e66a54fe78a35a98fb87
+  languageName: node
+  linkType: hard
+
 "dotenv@npm:10.0.0, dotenv@npm:^10.0.0":
   version: 10.0.0
   resolution: "dotenv@npm:10.0.0"
   checksum: f412c5fe8c24fbe313d302d2500e247ba8a1946492db405a4de4d30dd0eb186a88a43f13c958c5a7de303938949c4231c56994f97d05c4bc1f22478d631b4005
+  languageName: node
+  linkType: hard
+
+"dotenv@npm:^8.2.0":
+  version: 8.6.0
+  resolution: "dotenv@npm:8.6.0"
+  checksum: 38e902c80b0666ab59e9310a3d24ed237029a7ce34d976796349765ac96b8d769f6df19090f1f471b77a25ca391971efde8a1ea63bb83111bd8bec8e5cc9b2cd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR updates the eclipse mini (the only one so far that has any backend interaction) and the CI build to use an API key. The API key for the mini has extremely limited privileges, so I think the way this sets things up is fine, at least for now.