### PR TITLE
Add hover tooltip

### DIFF
--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -808,7 +808,6 @@
           >
             <template v-slot:target>
               <v-switch
-                v-if="!mobile"
                 inset
                 hide-details
                 :ripple="false"
@@ -822,18 +821,6 @@
                 tabindex="0"
               >
               </v-switch>
-              <v-btn
-                v-if="mobile"
-                :style="{'textTransform': 'none'}"
-                :variant="viewerMode === 'SunScope' ? 'tonal' : 'flat'"
-                density="comfortable"
-                @click="viewerMode = viewerMode === 'SunScope' ? 'Horizon' : 'SunScope'"
-                :ripple="false"
-                :color="accentColor"
-                :class="viewerMode === 'SunScope' ? 'sun-tracking' : 'sun-not-tracking'"
-                >
-                Switch to {{ viewerMode === 'SunScope' ? 'Horizon' : 'Eclipse' }} View
-              </v-btn>
             </template>
             Switch to {{ viewerMode === 'SunScope' ? 'Horizon' : 'Eclipse' }} View
         </hover-tooltip>
@@ -845,7 +832,6 @@
             >
               <template v-slot:target>
                 <v-switch
-                  v-if="!mobile"
                   inset
                   hide-details
                   v-model="toggleTrackSun"
@@ -857,19 +843,6 @@
                   tabindex="0"
                 >
                 </v-switch>
-                <v-btn
-                  v-if="mobile"
-                  :style="{'textTransform': 'none'}"
-                  :variant="toggleTrackSun ? 'tonal' : 'flat'"
-                  density="comfortable"
-                  @click="toggleTrackSun = !toggleTrackSun"
-                  :ripple="false"
-                  :color="accentColor"
-                  :class="toggleTrackSun ? 'sun-tracking' : 'sun-not-tracking'"
-                  >
-                  {{ toggleTrackSun ? 'Sun is Centerd' : 'Re-Center Sun' }}
-                </v-btn>                
-
             </template>
             {{ toggleTrackSun ? "Don't Track Sun" : 'Center on Sun' }}
           </hover-tooltip>

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -802,6 +802,7 @@
       </div>
       <div id="top-switches">
         <v-tooltip
+            v-if="!mobile"
             location="left"
             :color="accentColor"
             :style="cssVars"
@@ -851,7 +852,18 @@
                   false-icon="mdi-image"
                 >
                 </v-switch>
-                
+                <v-btn
+                  v-if="mobile"
+                  :style="{'textTransform': 'none'}"
+                  :variant="toggleTrackSun ? 'tonal' : 'flat'"
+                  density="comfortable"
+                  @click="toggleTrackSun = !toggleTrackSun"
+                  :ripple="false"
+                  :color="accentColor"
+                  :class="toggleTrackSun ? 'sun-tracking' : 'sun-not-tracking'"
+                  >
+                  {{ toggleTrackSun ? 'Sun is Centerd' : 'Re-Center Sun' }}
+                </v-btn>                
               </div>
             </template>
             {{ toggleTrackSun ? "Don't Track Sun" : 'Center on Sun' }}

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -808,7 +808,7 @@
           >
             <template v-slot:target>
               <v-switch
-              v-if="!mobile"
+                v-if="!mobile"
                 inset
                 hide-details
                 :ripple="false"
@@ -845,6 +845,7 @@
             >
               <template v-slot:target>
                 <v-switch
+                  v-if="!mobile"
                   inset
                   hide-details
                   v-model="toggleTrackSun"
@@ -3997,6 +3998,7 @@ body {
   #top-switches {
     position: absolute;
     right: 0;
+    text-align: right;
 
     @media (max-width: 750px) { //SMALL
       margin-top: 0.5rem;

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -801,17 +801,12 @@
       > </v-chip>
       </div>
       <div id="top-switches">
-        <v-tooltip
+        <hover-tooltip
             location="left"
-            :color="accentColor"
-            :style="cssVars"
             :disabled="mobile"
+            id="viewer-mode-switch"
           >
-          <template v-slot:activator="{props}">
-            <div 
-              v-bind="props"
-              id="viewer-mode-switch"
-              >
+            <template v-slot:target>
               <v-switch
               v-if="!mobile"
                 inset
@@ -837,23 +832,16 @@
                 >
                 Switch to {{ viewerMode === 'SunScope' ? 'Horizon' : 'Eclipse' }} View
               </v-btn>
-            
-            </div>
-          </template>
-          
-        </v-tooltip>
+            </template>
+            Switch to {{ viewerMode === 'SunScope' ? 'Horizon' : 'Eclipse' }} View
+        </hover-tooltip>
 
         <div id="track-sun-switch"> 
-          <v-tooltip
+          <hover-tooltip
               location="left"
-              :color="accentColor"
-              :style="cssVars"
               :disabled="mobile"
             >
-            <template v-slot:activator="{props}">
-              <div 
-                v-bind="props"
-              >
+              <template v-slot:target>
                 <v-switch
                   inset
                   hide-details
@@ -876,10 +864,10 @@
                   >
                   {{ toggleTrackSun ? 'Sun is Centerd' : 'Re-Center Sun' }}
                 </v-btn>                
-              </div>
+
             </template>
             {{ toggleTrackSun ? "Don't Track Sun" : 'Center on Sun' }}
-          </v-tooltip>
+          </hover-tooltip>
         </div>
       </div>
     </div>

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -802,7 +802,6 @@
       </div>
       <div id="top-switches">
         <v-tooltip
-            v-if="!mobile"
             location="left"
             :color="accentColor"
             :style="cssVars"
@@ -814,6 +813,7 @@
               id="viewer-mode-switch"
               >
               <v-switch
+              v-if="!mobile"
                 inset
                 hide-details
                 :ripple="false"
@@ -825,10 +825,22 @@
                 true-icon="mdi-image-filter-hdr"
               >
               </v-switch>
+              <v-btn
+                v-if="mobile"
+                :style="{'textTransform': 'none'}"
+                :variant="viewerMode === 'SunScope' ? 'tonal' : 'flat'"
+                density="comfortable"
+                @click="viewerMode = viewerMode === 'SunScope' ? 'Horizon' : 'SunScope'"
+                :ripple="false"
+                :color="accentColor"
+                :class="viewerMode === 'SunScope' ? 'sun-tracking' : 'sun-not-tracking'"
+                >
+                Switch to {{ viewerMode === 'SunScope' ? 'Horizon' : 'Eclipse' }} View
+              </v-btn>
             
             </div>
           </template>
-          Switch to {{ viewerMode === 'SunScope' ? 'Horizon' : 'Eclipse Scope' }} View
+          
         </v-tooltip>
 
         <div id="track-sun-switch"> 

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -818,6 +818,8 @@
                 false-icon="mdi-telescope"
                 true-value="Horizon"
                 true-icon="mdi-image-filter-hdr"
+                @keyup.enter="viewerMode = viewerMode === 'SunScope' ? 'Horizon' : 'SunScope'"
+                tabindex="0"
               >
               </v-switch>
               <v-btn
@@ -850,6 +852,8 @@
                   :color="accentColor"
                   true-icon="mdi-white-balance-sunny"
                   false-icon="mdi-image"
+                  @keyup.enter="toggleTrackSun = !toggleTrackSun"
+                  tabindex="0"
                 >
                 </v-switch>
                 <v-btn

--- a/annular-eclipse-2023/src/HoverTooltip.vue
+++ b/annular-eclipse-2023/src/HoverTooltip.vue
@@ -1,0 +1,103 @@
+<template>
+  <v-tooltip
+    v-model="tooltip"
+    :location="tooltipLocation as LocationType"
+    :open-on-click="tooltipOnClick"
+    :open-on-focus="tooltipOnFocus"
+    :open-on-hover="tooltipOnHover"
+    :offset="tooltipOffset"
+    :disabled="!tooltipText || !showTooltip"
+    v-bind="$attrs"
+  >
+    <template v-slot:activator="{ props }: { props: Record<string,any> }">
+      <div
+        v-bind="props"
+        :id="buttonID"
+        @touchstart="handleTouchStart"
+        @touchend="handleTouchEnd"
+      >
+        <slot name="target">
+          
+        </slot>
+      </div>
+    </template>
+    <slot>
+      <span>{{ tooltipText }}</span>
+    </slot>
+  </v-tooltip>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+import { VTooltip } from "vuetify/components/VTooltip";
+
+
+declare const block: readonly ["top", "bottom"];
+declare const inline: readonly ["start", "end", "left", "right"];
+type Tblock = typeof block[number];
+type Tinline = typeof inline[number];
+type Anchor = Tblock | Tinline | 'center' | 'center center' | `${Tblock} ${Tinline | 'center'}` | `${Tinline} ${Tblock | 'center'}`;
+
+type LocationType = NonNullable<Anchor>;
+
+export default defineComponent({
+
+  components: {
+    'v-tooltip': VTooltip,
+  },
+
+  inheritAttrs: false,
+
+  props: {
+
+    longPressTimeMs: { type: Number, default: 500 },
+    tooltipText: { type: String, required: false },
+    tooltipLocation: { type: String, default: "start" as LocationType},
+    tooltipOnClick: { type: Boolean, default: false },
+    tooltipOnFocus: { type: Boolean, default: false },
+    tooltipOnHover: { type: Boolean, default: true },
+    tooltipOffset: { type: [String, Number], default: 0 },
+    showTooltip: { type: Boolean, default: true },
+  },
+
+  methods: {
+
+    handleTouchStart() {
+      this.longPressTimeout = setTimeout(() => {
+        this.tooltip = true;
+      }, this.longPressTimeMs);
+    },
+
+    handleTouchEnd() {
+      if (this.longPressTimeout) {
+        clearTimeout(this.longPressTimeout);
+        this.longPressTimeout = null;
+      }
+      this.tooltip = false;
+    }
+  },
+
+  data() {
+    return {
+      tooltip: false,
+      longPressTimeout: null as ReturnType<typeof setTimeout> | null
+    };
+  },
+
+  // Since our colors are used in compound values like e.g. box-shadows,
+  // we need to directly bind to CSS variables
+  computed: {
+
+    buttonID() {
+      const id = this.$attrs['id'];
+      return id ? `${id}-button` : undefined;
+    },
+  }
+
+});
+</script>
+
+<style lang="less">
+
+
+</style>

--- a/annular-eclipse-2023/src/main.ts
+++ b/annular-eclipse-2023/src/main.ts
@@ -10,6 +10,7 @@ import Credits from "./Credits.vue";
 import MCRadiogroup from "./MCRadiogroup.vue";
 import FlipTransition from "./FlipTransition.vue";
 import ImageLabel from "./ImageLabel.vue";
+import HoverTooltip from "./HoverTooltip.vue";
 
 import "./polyfills";
 
@@ -126,6 +127,7 @@ createApp(AnnularEclipse2023, {
   .component('flip-transition', FlipTransition)
   .component('image-label', ImageLabel)
   .component('funding-acknowledgment', FundingAcknowledgment)
+  .component('hover-tooltip', HoverTooltip)
 
   // Mount
   .mount("#app");


### PR DESCRIPTION
This adds a hover tooltip and makes the switches more accessible. 

It also shows the toggles as buttons on mobile, but this can be disabled easily. It was an option created before the hover tooltip was available.