### PR TITLE
Update Vue config to remove `DefinePlugin` warning

### DIFF
--- a/annular-eclipse-2023/vue.config.js
+++ b/annular-eclipse-2023/vue.config.js
@@ -10,7 +10,10 @@ module.exports = defineConfig({
       new VuetifyPlugin(),
       new DotenvWebpack({
         path: ".env",
-        systemvars: true
+        systemvars: true,
+
+        // See https://stackoverflow.com/questions/67431401/conflicting-values-for-process-env-with-webpack-encore-and-dotenv
+        ignoreStub: true
       })
     ]
   },


### PR DESCRIPTION
This PR removes the `DefinePlugin Conflicting values for 'process.env'` warning that we were seeing.