### PR TITLE
Restyle video so user can leave

### DIFF
--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -282,12 +282,15 @@
         @keyup.enter="showVideoSheet = false"
         tabindex="0"
       ></font-awesome-icon>
-      <video
-        controls
+      <iframe height="700"
         id="info-video"
-      >
-        <source src="./assets/video.mp4" type="video/mp4">
-      </video>
+        src="https://www.youtube.com/embed/KX_bDgOFqPM?&autoplay=1"
+        title="YouTube video player"
+        frameborder="0"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+        allowfullscreen>
+      </iframe>
+
     </div>
   </v-dialog>
   
@@ -3592,18 +3595,22 @@ body {
   }
 }
 
-.video-wrapper {
+.video-wrapper {  
+  display: flex;
   height: 100%;
-  background: black;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(2px);
   text-align: center;
   z-index: 1000;
 }
 
-video {
-  height: 100%;
+video, #info-video {
+  margin: auto;
+  height: 85%;
   width: auto;
   max-width: 100%;
   object-fit: contain;
+  aspect-ratio: 9/17;
 }
 
 #video-container {

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -270,6 +270,8 @@
     id="video-container"
     v-model="showVideoSheet"
     transition="slide-y-transition"
+    close-on-back
+    close-on-content-click
     fullscreen
   >
     <div class="video-wrapper">
@@ -1930,12 +1932,12 @@ export default defineComponent({
       get(): boolean {
         return this.sheet === "video";
       },
-      set(value: boolean) {
+      set(_value: boolean) {
         this.selectSheet('video');
-        if (!value) {
-          const video = document.querySelector("#info-video") as HTMLVideoElement;
-          video.pause();
-        }
+        // if (!value) {
+        //   // const video = document.querySelector("#info-video") as HTMLVideoElement;
+        //   // video.pause();
+        // }
       }
     },
   },

--- a/annular-eclipse-2023/src/AnnularEclipse2023.vue
+++ b/annular-eclipse-2023/src/AnnularEclipse2023.vue
@@ -271,7 +271,6 @@
     v-model="showVideoSheet"
     transition="slide-y-transition"
     close-on-back
-    close-on-content-click
     fullscreen
   >
     <div class="video-wrapper">
@@ -284,15 +283,12 @@
         @keyup.enter="showVideoSheet = false"
         tabindex="0"
       ></font-awesome-icon>
-      <iframe height="700"
+      <video
+        controls
         id="info-video"
-        src="https://www.youtube.com/embed/KX_bDgOFqPM?&autoplay=1"
-        title="YouTube video player"
-        frameborder="0"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-        allowfullscreen>
-      </iframe>
-
+      >
+        <source src="./assets/video.mp4" type="video/mp4">
+      </video>
     </div>
   </v-dialog>
   
@@ -3612,7 +3608,8 @@ video, #info-video {
   width: auto;
   max-width: 100%;
   object-fit: contain;
-  aspect-ratio: 9/17;
+  // aspect-ratio: 9/17;
+  border: 5px solid white;
 }
 
 #video-container {


### PR DESCRIPTION
originally this switched to use the youtube video, but since we can't control the end card, I kept the normal (mp4) video. On my phone, I couldn't see the close button - so this just makes the video use less space (in line with the pinwheel video embed) so that the close button is obvious. @patudom or @Carifio24 could you check this and merge if you think it's appropriate