### PR TITLE
Allow setting location select event via prop

### DIFF
--- a/common/src/components/LocationSelector.vue
+++ b/common/src/components/LocationSelector.vue
@@ -104,6 +104,10 @@ export default defineComponent({
         };
       }
     },
+    selectionEvent: {
+      type: String as PropType<'click' | 'dblclick'>,
+      default: 'click'
+    },
     worldRadii: {
       type: Boolean,
       default: false
@@ -244,7 +248,7 @@ export default defineComponent({
 
       map.doubleClickZoom.disable();
       if (this.selectable) {
-        map.on('click', this.onMapSelect);
+        map.on(this.selectionEvent, this.onMapSelect);
       }
 
       map.attributionControl.setPrefix('<a href="https://leafletjs.com" title="A JavaScript library for interactive maps" target="_blank" rel="noopener noreferrer" >Leaflet</a>');


### PR DESCRIPTION
This PR updates the location selector to allow controlling whether we want single- or double-click selection is controlled via a prop.

I've set the default as single-click, which means that we don't need to update the eclipse mini.