### PR TITLE
Formatting branch 2

### DIFF
--- a/jwst-brick/src/JwstBrick.vue
+++ b/jwst-brick/src/JwstBrick.vue
@@ -104,13 +104,13 @@
         <div
           v-if="showJWSTOpacity"
           id="jwst-crossfade">
-          <span>Stars</span>
+          <span class="mobile-off">Stars</span>
           <input
             class="opacity-range"
             type="range"
             v-model="crossfadeJWST"
           />
-          <span>No stars</span>
+          <span class="mobile-off">No stars</span>
         </div>
       </places-gallery>
     </div>
@@ -1251,6 +1251,16 @@ a {
 #main-content {
   .gallery-root .gallery {
     border: none;
+  }
+}
+
+@media only screen and (max-width: 600px) {
+  #icons-container {
+    display: none;
+  }
+
+  .mobile-off {
+    display: none;
   }
 }
 

--- a/jwst-brick/src/PlacesGallery.vue
+++ b/jwst-brick/src/PlacesGallery.vue
@@ -101,7 +101,7 @@ export default defineComponent({
     width: { type: String, default: "300px" },
     maxHeight: { type: String, default: "500px" },
     title: { type: String, default: "Gallery" },
-    selectedColor: { type: String, default: "dodgerblue" },
+    selectedColor: { type: String, default: "deepskyblue" },
     singleSelect: { type: Boolean, default: true },
     highlightLastOnly: { type: Boolean, default: false },
     previewIndex: { type: Number, default: 0 },
@@ -319,7 +319,7 @@ export default defineComponent({
   .gallery-item {
     padding: 2px 10px;
     border-radius: 5px;
-    border: 2px solid white;
+    border: 2px solid #999;
     display: flex;
     flex-direction: column;
     cursor: pointer;

--- a/jwst-brick/src/PlacesGallery.vue
+++ b/jwst-brick/src/PlacesGallery.vue
@@ -56,7 +56,7 @@
           @click="selectPlace(place)"
         >
           <img
-            class="noselect"
+            class="noselect mobile-off"
             :src="getImageset(place)?.get_thumbnailUrl() ?? ''"
           />
           <span


### PR DESCRIPTION
Updates the colors for the borders for the gallery items whether selected/unselected, so that it's clearer which one is being highlighted and which one is inactive.

Also hides multiple features from visibility when viewed on mobile, to de-crowd the main screen. Items removed are:
 - Partner icons in bottom-right
 - Gallery item thumbnails
 - Text labels for left and right ends of the slider