### PR TITLE
make wwt canvas background black by default

### DIFF
--- a/assets/common.less
+++ b/assets/common.less
@@ -77,6 +77,9 @@ body {
     margin: 0;
     padding: 0;
     transition: height .25s ease;
+    canvas {
+      background-color: black;
+    }
   }
 }
 


### PR DESCRIPTION
Sets the WWT Canvas background color to black to it displays properly