### PR TITLE
Disable error overlay on Webpack dev server.

### DIFF
--- a/annular-eclipse-2023/vue.config.js
+++ b/annular-eclipse-2023/vue.config.js
@@ -22,6 +22,9 @@ module.exports = defineConfig({
   // dev server insecure, but that's OK since we only use it in controlled
   // circumstances. https://stackoverflow.com/questions/43619644
   devServer: {
-    allowedHosts: 'all'
+    allowedHosts: 'all',
+    client: {
+      overlay: false
+    }
   }
 });

--- a/carina/vue.config.js
+++ b/carina/vue.config.js
@@ -14,6 +14,9 @@ module.exports = defineConfig({
   // dev server insecure, but that's OK since we only use it in controlled
   // circumstances. https://stackoverflow.com/questions/43619644
   devServer: {
-    allowedHosts: 'all'
+    allowedHosts: 'all',
+    client: {
+      overlay: false
+    }
   }
 });

--- a/green-comet/vue.config.js
+++ b/green-comet/vue.config.js
@@ -14,6 +14,9 @@ module.exports = defineConfig({
   // dev server insecure, but that's OK since we only use it in controlled
   // circumstances. https://stackoverflow.com/questions/43619644
   devServer: {
-    allowedHosts: 'all'
+    allowedHosts: 'all',
+    client: {
+      overlay: false
+    }
   }
 });

--- a/jwst-brick/vue.config.js
+++ b/jwst-brick/vue.config.js
@@ -14,6 +14,9 @@ module.exports = defineConfig({
   // dev server insecure, but that's OK since we only use it in controlled
   // circumstances. https://stackoverflow.com/questions/43619644
   devServer: {
-    allowedHosts: 'all'
+    allowedHosts: 'all',
+    client: {
+      overlay: false
+    }
   }
 });

--- a/pinwheel-supernova/vue.config.js
+++ b/pinwheel-supernova/vue.config.js
@@ -14,6 +14,9 @@ module.exports = defineConfig({
   // dev server insecure, but that's OK since we only use it in controlled
   // circumstances. https://stackoverflow.com/questions/43619644
   devServer: {
-    allowedHosts: 'all'
+    allowedHosts: 'all',
+    client: {
+      overlay: false
+    }
   }
 });

--- a/radwave/vue.config.js
+++ b/radwave/vue.config.js
@@ -22,6 +22,9 @@ module.exports = defineConfig({
   // dev server insecure, but that's OK since we only use it in controlled
   // circumstances. https://stackoverflow.com/questions/43619644
   devServer: {
-    allowedHosts: 'all'
+    allowedHosts: 'all',
+    client: {
+      overlay: false
+    }
   }
 });

--- a/solar-eclipse-2024/vue.config.js
+++ b/solar-eclipse-2024/vue.config.js
@@ -30,6 +30,9 @@ module.exports = defineConfig({
   // dev server insecure, but that's OK since we only use it in controlled
   // circumstances. https://stackoverflow.com/questions/43619644
   devServer: {
-    allowedHosts: 'all'
+    allowedHosts: 'all',
+    client: {
+      overlay: false
+    }
   }
 });

--- a/template/vue.config.js
+++ b/template/vue.config.js
@@ -14,6 +14,9 @@ module.exports = defineConfig({
   // dev server insecure, but that's OK since we only use it in controlled
   // circumstances. https://stackoverflow.com/questions/43619644
   devServer: {
-    allowedHosts: 'all'
+    allowedHosts: 'all',
+    client: {
+      overlay: false
+    }
   }
 });


### PR DESCRIPTION
This PR resolves #317 by updating the configuration for the dev server. I've updated this in all of the minis as well as in the template so that it'll be taken care of going forward.