### PR TITLE
Remove empty mounted methods

### DIFF
--- a/annular-eclipse-2023/src/GeolocationButton.vue
+++ b/annular-eclipse-2023/src/GeolocationButton.vue
@@ -179,10 +179,6 @@ export default defineComponent({
       loading: false,
     };
   },
-  mounted() {
-
-    
-  },
 
   computed: {
     icon() {

--- a/solar-eclipse-2024/src/GeolocationButton.vue
+++ b/solar-eclipse-2024/src/GeolocationButton.vue
@@ -179,10 +179,6 @@ export default defineComponent({
       loading: false,
     };
   },
-  mounted() {
-
-    
-  },
 
   computed: {
     icon() {


### PR DESCRIPTION
When I try to build all of the minis, I'm currently getting an ESLint error about an empty `mounted` method in the solar eclipse mini's geolocation button. For whatever reason the same issue is ignored in the annular eclipse mini. To avoid having to deal with this issue again, this PR removes the empty method in both.