### PR TITLE
Use square annotation for Sun marker

### DIFF
--- a/radwave/src/Radwave.vue
+++ b/radwave/src/Radwave.vue
@@ -727,7 +727,7 @@ export default defineComponent({
 
       this.setBackgroundImageByName("Solar System");
       this.setForegroundImageByName("Solar System");
-      this.sunLayer?.set_opacity(1);
+      this.sunLayer?.set_opacity(0);
       updateBestFitAnnotations(phase);
 
 
@@ -886,7 +886,8 @@ export default defineComponent({
           id: layer.id.toString(),
           settings: [
             ["color", Color.load(this.sunColor)],
-            ["scaleFactor", 100]
+            ["scaleFactor", 100],
+            ["opacity", 0]
           ]
         });
         return layer;
@@ -908,7 +909,7 @@ export default defineComponent({
       let alt = row[dCol];
       alt = (altFactor * alt);
       const sunPos = Coordinates.geoTo3dRad(row[latCol], row[lngCol], alt);
-      const squareSideLength = 30000000;
+      const squareSideLength = 10000000;
       const halfSideLength = squareSideLength / 2;
       const threeD = WWTControl.singleton.renderType == ImageSetType.solarSystem;
       const pts = [

--- a/radwave/src/Radwave.vue
+++ b/radwave/src/Radwave.vue
@@ -16,7 +16,7 @@
       :wwt-namespace="wwtNamespace"
       :location="{top: '5rem', right: '1rem'}"
       :offset-center="{x: 0, y: 0}"
-      :other-variables="{position3D: position3D, position2D: position2D, mode: modeReactive}"
+      :other-variables="{position3D: position3D, position2D: position2D, mode: mode}"
       text-shadow="none"
       font-size="0.8em"
     ></wwt-hud>
@@ -96,7 +96,7 @@
     <!-- This block contains the elements (e.g. icon buttons displayed at/near the top of the screen -->
 
     <div class="top-content">
-      <div v-if="modeReactive != null" id="left-buttons">
+      <div v-if="mode != null" id="left-buttons">
         <icon-button
           v-model="showTextSheet"
           fa-icon="book-open"
@@ -126,20 +126,20 @@
           tooltip-location="bottom"
         >
         <template v-slot:button>
-          <span v-if="modeReactive != 'full'" class="no-select">View the Full Radcliffe Wave</span>
-          <v-icon v-if="modeReactive == 'full'">mdi-arrow-left</v-icon>
+          <span v-if="mode != 'full'" class="no-select">View the Full Radcliffe Wave</span>
+          <v-icon v-if="mode == 'full'">mdi-arrow-left</v-icon>
         </template>
         </icon-button>
         
         <icon-button
-          v-if="(playCount > 0) ?? (modeReactive == 'full')"
-          @activate="modeReactive = modeReactive == '3D' ? '2D' : '3D'"
+          v-if="(playCount > 0) ?? (mode == 'full')"
+          @activate="mode = mode == '3D' ? '2D' : '3D'"
           :color="buttonColor"
           tooltip-text="Switch modes"
           tooltip-location="start"
         >
         <template v-slot:button>
-          <span class="no-select">See this {{ modeReactive == '3D' ? ' on the Sky (2D)' : 'in the Galaxy (3D)' }}</span>
+          <span class="no-select">See this {{ mode == '3D' ? ' on the Sky (2D)' : 'in the Galaxy (3D)' }}</span>
         </template>
         </icon-button>
         <icon-button
@@ -162,7 +162,7 @@
     <!-- This block contains the elements (e.g. the project icons) displayed along the bottom of the screen -->
 
     <div class="bottom-content">
-      <div v-if="modeReactive != '2D'" id="time-controls">
+      <div v-if="mode != '2D'" id="time-controls">
         <icon-button
           v-model="playing"
           :fa-icon="playing ? 'pause' : 'play'"
@@ -185,7 +185,7 @@
       </div>
       <div v-else id="time-controls" style="width:50%">
         <v-select
-          v-if="modeReactive == '2D'"
+          v-if="mode == '2D'"
           v-model="background2DImageset"
           :items="allSkyImagesets"
           label="Background"
@@ -354,7 +354,7 @@ import { Annotation, Color, PolyLine, SpaceTimeController, SpreadSheetLayer, WWT
 // @ts-ignore
 import { Coordinates } from "@wwtelescope/engine";
 import { GotoRADecZoomParams } from "@wwtelescope/engine-pinia";
-import { AltTypes, AltUnits, MarkerScales, RAUnits } from "@wwtelescope/engine-types";
+import { AltTypes, AltUnits, ImageSetType, MarkerScales, RAUnits } from "@wwtelescope/engine-types";
 
 import sunCsv from "./assets/Sun_radec.csv";
 import bestFitCsv from "./assets/radwave/RW_best_fit_oscillation_phase_radec_downsampled.csv";
@@ -395,7 +395,6 @@ const endTime = endDate.getTime();
 
 let phase = 0;
 let altFactor = 1;
-let mode = "3D" as "2D" | "3D" | "full" | null;
 
 const phaseRowCount = 300;
 
@@ -441,7 +440,8 @@ function addPhasePointsToAnnotation(layer: SpreadSheetLayer, annotation: Annotat
     let alt = row[dCol];
     alt = (altFactor * alt);
     const pos = Coordinates.geoTo3dRad(row[latCol], row[lngCol], alt);
-    if (mode == "3D") {
+    const threeD = WWTControl.singleton.renderType === ImageSetType.solarSystem;
+    if (threeD) {
       pos.rotateX(ecliptic);
     }
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -449,7 +449,6 @@ function addPhasePointsToAnnotation(layer: SpreadSheetLayer, annotation: Annotat
     annotation._points$1.push(pos);
   }
 }
-
 
 
 function updateSlider(value: number) {
@@ -532,7 +531,7 @@ export default defineComponent({
       sunColor: "#ffff0a",
       sunLayer: null as SpreadSheetLayer | null,
       
-      modeReactive: mode as "2D" | "3D" | "full" | null,
+      mode: "3D" as "2D" | "3D" | "full" | null,
       resizeObserver: null as ResizeObserver | null,
       background2DImageset: "Deep Star Maps 2020",
       position3D: this.initialCameraParams as Omit<GotoRADecZoomParams,'instant'>,
@@ -744,18 +743,18 @@ export default defineComponent({
       // to view in the full wave you need to adjust the height
       // of the window/canvas to have an W:H ration of 5.7
       let old3D = null as unknown as Omit<GotoRADecZoomParams,'instant'>;
-      if (this.modeReactive == 'full') {
-        this.modeReactive = this.previousMode;
+      if (this.mode == 'full') {
+        this.mode = this.previousMode;
         this.positionReset();
         return;
-      } else if (this.modeReactive == '3D') {
+      } else if (this.mode == '3D') {
         old3D = this.wwtPosition;
       }
       
       return this.set2DMode().then(() => {
-        this.previousMode = this.modeReactive;
-        this.modeReactive = "full";
-        phase=0;
+        this.previousMode = this.mode;
+        this.mode = "full";
+        phase = 0;
         
         this.shinkWWT();
         this.resizeObserver?.observe(document.body);
@@ -765,7 +764,9 @@ export default defineComponent({
           instant: false}).catch((err) => {
           console.log(err);
         }).then(() => {
-          if (old3D) {this.position3D = old3D;}
+          if (old3D) {
+            this.position3D = old3D;
+          }
         });
       });
       
@@ -799,14 +800,14 @@ export default defineComponent({
       
       // only reset the current mode
       let pos = null as unknown as Omit<GotoRADecZoomParams, "instant">;
-      if (this.modeReactive == "2D") {
+      if (this.mode == "2D") {
         this.position2D = this.initial2DPosition;
         pos = this.position2D;
         
-      } else if (this.modeReactive == "3D") {
+      } else if (this.mode == "3D") {
         this.position3D = this.initialCameraParams;
         pos = this.position3D;
-      } else if (this.modeReactive == 'full') {
+      } else if (this.mode == 'full') {
         pos = this.fullwavePosition;
       }
       
@@ -984,7 +985,7 @@ export default defineComponent({
     
     background2DImageset(name: string) {
       
-      if (this.modeReactive == "2D") {
+      if (this.mode == "2D") {
         this.setBackgroundImageByName(name);
         return;
       }
@@ -1023,7 +1024,6 @@ export default defineComponent({
     // },
     
     modeReactive(newVal, oldVal) {
-      mode = newVal;
       if (oldVal == newVal) {
         if (newVal == "2D") {
           this.set2DMode();

--- a/radwave/src/Radwave.vue
+++ b/radwave/src/Radwave.vue
@@ -592,7 +592,7 @@ export default defineComponent({
       
     });
     this.resizeObserver = new ResizeObserver((_entries) => {
-      this.shinkWWT();
+      this.shrinkWWT();
     });
     
   },
@@ -758,7 +758,7 @@ export default defineComponent({
         this.mode = "full";
         phase = 0;
         
-        this.shinkWWT();
+        this.shrinkWWT();
         this.resizeObserver?.observe(document.body);
         
         return this.gotoRADecZoom({
@@ -824,12 +824,12 @@ export default defineComponent({
       
     },
     
-    shinkWWT(aspect: number = null as unknown as number) {
+    shrinkWWT(aspect: number = null as unknown as number) {
       // default aspect = 5.7
       if (aspect == null) {
         aspect = 5.7;
       }
-      console.log('shinkWWT');
+      console.log('shrinkWWT');
       
       const mainContent = document.querySelector(".wwtelescope-component") as HTMLElement;
       const width = mainContent.clientWidth;


### PR DESCRIPTION
This is an alternative solution to #331 (contrast with #333 - we can just close whichever of these we don't end up going with). The solution here is to use an unfilled square annotation to mark the Sun's position. This isn't filled for reasons discussed in #333. The advantage here is that the annotation is something that will respect the camera orientation, rather than the always-face-on image in #333.

Note that this branch also contains the removal of the non-reactive mode and the typo fix that are in #333 - the only difference is what we're using to mark the Sun's current position.